### PR TITLE
Shottimer update

### DIFF
--- a/rancilio-pid/Displaytemplateminimal.h
+++ b/rancilio-pid/Displaytemplateminimal.h
@@ -58,7 +58,7 @@ void printScreen()
       }
 
       u8g2.print("Brew:  ");
-      u8g2.print(bezugsZeit / 1000, 1);
+      u8g2.print(bezugsZeit / 1000, 0);
       u8g2.print("/");
       if (ONLYPID == 1) {
         u8g2.print(brewtimersoftware, 0);             // deaktivieren wenn Preinfusion ( // voransetzen )

--- a/rancilio-pid/Displaytemplateminimal.h
+++ b/rancilio-pid/Displaytemplateminimal.h
@@ -3,7 +3,7 @@
 ******************************************************/
 void printScreen() 
 {
-  if (SHOTTIMER == 1 && bezugsZeit > 0) return; 
+  if ((SHOTTIMER == 1 && bezugsZeit > 0|| (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+3000 >= millis())) return; 
   unsigned long currentMillisDisplay = millis();
   if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
     previousMillisDisplay = currentMillisDisplay;

--- a/rancilio-pid/Displaytemplateminimal.h
+++ b/rancilio-pid/Displaytemplateminimal.h
@@ -3,7 +3,8 @@
 ******************************************************/
 void printScreen() 
 {
-  if ((SHOTTIMER == 1 && bezugsZeit > 0|| (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+3000 >= millis())) return; 
+  if ((SHOTTIMER == 1 && bezugsZeit > 0) || 
+  (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+brewswitchDelay >= millis())) // sobald der Brühschalter umgelegt wird, brewswitchDelay abgelaufen
   unsigned long currentMillisDisplay = millis();
   if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
     previousMillisDisplay = currentMillisDisplay;

--- a/rancilio-pid/Displaytemplateminimal.h
+++ b/rancilio-pid/Displaytemplateminimal.h
@@ -5,6 +5,7 @@ void printScreen()
 {
   if ((SHOTTIMER == 1 && bezugsZeit > 0) || 
   (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+brewswitchDelay >= millis())) // sobald der Brühschalter umgelegt wird, brewswitchDelay abgelaufen
+  return;
   unsigned long currentMillisDisplay = millis();
   if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
     previousMillisDisplay = currentMillisDisplay;

--- a/rancilio-pid/Displaytemplatestandard.h
+++ b/rancilio-pid/Displaytemplatestandard.h
@@ -95,7 +95,7 @@ void printScreen()
       }
       else
       {
-        u8g2.print(totalbrewtime / 1000);            // aktivieren wenn Preinfusion
+        u8g2.print(totalbrewtime / 1000, 1);            // aktivieren wenn Preinfusion und eine Nachkommastelle oder alternativ keine
       }
       //draw box
       u8g2.drawFrame(0, 0, 128, 64);

--- a/rancilio-pid/Displaytemplatestandard.h
+++ b/rancilio-pid/Displaytemplatestandard.h
@@ -6,8 +6,9 @@
 
 void printScreen() 
 {
-  if ((SHOTTIMER == 1 && bezugsZeit > 0) || (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+3000 >= millis())) return; 
-  unsigned long currentMillisDisplay = millis();
+  if ((SHOTTIMER == 1 && bezugsZeit > 0) || 
+  (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+brewswitchDelay >= millis())) // sobald der Brühschalter umgelegt wird, brewswitchDelay abgelaufen
+  return; 
   if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
     previousMillisDisplay = currentMillisDisplay;
     if (!sensorError) {

--- a/rancilio-pid/Displaytemplatestandard.h
+++ b/rancilio-pid/Displaytemplatestandard.h
@@ -88,7 +88,7 @@ void printScreen()
       // Brew
       u8g2.setCursor(32, 34);
       u8g2.print("Brew:  ");
-      u8g2.print(bezugsZeit / 1000, 1);
+      u8g2.print(bezugsZeit / 1000, 0);
       u8g2.print("/");
       if (ONLYPID == 1) {
         u8g2.print(brewtimersoftware, 0);             // deaktivieren wenn Preinfusion ( // voransetzen )

--- a/rancilio-pid/Displaytemplatestandard.h
+++ b/rancilio-pid/Displaytemplatestandard.h
@@ -6,7 +6,7 @@
 
 void printScreen() 
 {
-  if (SHOTTIMER == 1 && bezugsZeit > 0) return; 
+  if ((SHOTTIMER == 1 && bezugsZeit > 0) || (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+3000 >= millis())) return; 
   unsigned long currentMillisDisplay = millis();
   if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
     previousMillisDisplay = currentMillisDisplay;

--- a/rancilio-pid/Displaytemplatestandard.h
+++ b/rancilio-pid/Displaytemplatestandard.h
@@ -8,7 +8,8 @@ void printScreen()
 {
   if ((SHOTTIMER == 1 && bezugsZeit > 0) || 
   (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+brewswitchDelay >= millis())) // sobald der Brühschalter umgelegt wird, brewswitchDelay abgelaufen
-  return; 
+  return;
+  unsigned long currentMillisDisplay = millis();
   if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
     previousMillisDisplay = currentMillisDisplay;
     if (!sensorError) {

--- a/rancilio-pid/display.ino
+++ b/rancilio-pid/display.ino
@@ -106,7 +106,7 @@
             u8g2.sendBuffer();
             
         }
-        if (millis() >= bezugszeit_last_Millis && // direkt nach Erstellen von bezugszeit_last_mills (passiert beim ausschalten des Brühschalters, case 43 im Code) soll gestartet werden
+        if (SHOTTIMER == 1 && millis() >= bezugszeit_last_Millis && // direkt nach Erstellen von bezugszeit_last_mills (passiert beim ausschalten des Brühschalters, case 43 im Code) soll gestartet werden
         bezugszeit_last_Millis+brewswitchDelay >= millis() && // soll solange laufen, bis millis() den brewswitchDelay aufgeholt hat, damit kann die Anzeigedauer gesteuert werden
         bezugszeit_last_Millis < totalbrewtime) // wenn die totalbrewtime automatisch erreicht wird, soll nichts gemacht werden, da sonst falsche Zeit angezeigt wird, da Schalter später betätigt wird als totalbrewtime
         {

--- a/rancilio-pid/display.ino
+++ b/rancilio-pid/display.ino
@@ -104,6 +104,17 @@
             u8g2.print(bezugsZeit / 1000, 1);
             u8g2.setFont(u8g2_font_profont11_tf);
             u8g2.sendBuffer();
+            
+        }
+        if (millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+3000 >= millis()&& bezugszeit_last_Millis < totalbrewtime)
+        {
+           u8g2.clearBuffer();
+           u8g2.drawXBMP(0, 0, brewlogo_width, brewlogo_height, brewlogo_bits_u8g2);
+           u8g2.setFont(u8g2_font_profont22_tf);
+           u8g2.setCursor(64, 25);
+           u8g2.print((bezugszeit_last_Millis - startZeit) / 1000, 1);
+           u8g2.setFont(u8g2_font_profont11_tf);
+           u8g2.sendBuffer();
         }
     }
 

--- a/rancilio-pid/display.ino
+++ b/rancilio-pid/display.ino
@@ -106,9 +106,11 @@
             u8g2.sendBuffer();
             
         }
-        if (millis() >= bezugszeit_last_Millis && bezugszeit_last_Millis+3000 >= millis()&& bezugszeit_last_Millis < totalbrewtime)
+        if (millis() >= bezugszeit_last_Millis && // direkt nach Erstellen von bezugszeit_last_mills (passiert beim ausschalten des Brühschalters, case 43 im Code) soll gestartet werden
+        bezugszeit_last_Millis+brewswitchDelay >= millis() && // soll solange laufen, bis millis() den brewswitchDelay aufgeholt hat, damit kann die Anzeigedauer gesteuert werden
+        bezugszeit_last_Millis < totalbrewtime) // wenn die totalbrewtime automatisch erreicht wird, soll nichts gemacht werden, da sonst falsche Zeit angezeigt wird, da Schalter später betätigt wird als totalbrewtime
         {
-           u8g2.clearBuffer();
+            u8g2.clearBuffer();
            u8g2.drawXBMP(0, 0, brewlogo_width, brewlogo_height, brewlogo_bits_u8g2);
            u8g2.setFont(u8g2_font_profont22_tf);
            u8g2.setCursor(64, 25);

--- a/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid.ino
@@ -54,6 +54,7 @@ const int grafana = GRAFANA;
 const unsigned long wifiConnectionDelay = WIFICINNECTIONDELAY;
 const unsigned int maxWifiReconnects = MAXWIFIRECONNECTS;
 int machineLogo = MACHINELOGO;
+const unsigned long brewswitchDelay = BREWSWITCHDELAY;
 
 // Wifi
 const char* hostname = HOSTNAME;

--- a/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid.ino
@@ -153,7 +153,8 @@ double brewtime = 25000;  //brewtime in ms
 double totalbrewtime = 0; //total brewtime set in softare or blynk
 double preinfusion = 2000;  //preinfusion time in ms
 double preinfusionpause = 5000;   //preinfusion pause time in ms
-unsigned long bezugsZeit = 0;   //total brewed time
+double bezugsZeit = 0;   //total brewed time
+double bezugszeit_last_Millis = 0; // for shottimer delay after disarmed button
 unsigned long startZeit = 0;    //start time of brew
 const unsigned long analogreadingtimeinterval = 10 ; // ms
 unsigned long previousMillistempanalogreading ; // ms for analogreading
@@ -599,6 +600,7 @@ void brew()
         if (brewswitch < 1000) {
           digitalWrite(pinRelayVentil, relayOFF);
           digitalWrite(pinRelayPumpe, relayOFF);
+          bezugszeit_last_Millis = millis();  // for shottimer delay after disarmed button
           currentMillistemp = 0;
           bezugsZeit = 0;
           brewDetected = 0; //rearm brewdetection

--- a/rancilio-pid/userConfig.h
+++ b/rancilio-pid/userConfig.h
@@ -16,6 +16,7 @@
 #define MACHINELOGO 1        // 1 = Rancilio, 2 = Gaggia
 #define DISPALYROTATE U8G2_R0   // rotate display clockwise: U8G2_R0 = no rotation; U8G2_R1 = 90°; U8G2_R2 = 180°; U8G2_R3 = 270°
 #define SHOTTIMER  1 // 0: no SHOTTIMER, 1: SHOTTIMER
+#define BREWSWITCHDELAY 3000 // time in ms
 
 // Wlan and Connection
 #define OFFLINEMODUS 0       // 0 = Blynk and WIFI are used; 1 = offline mode (only preconfigured values in code are used!)


### PR DESCRIPTION
Shottimer zeigt noch für eine bestimmte Zeit nach dem Zurücksetzen des Brühschalters die Shotzeit an.
Hauptsächlich, um bei selbständigem Stoppen des Shots die gebrauchte Zeit noch ablesen zu können.
Zeit ist per Userconfig einstellbar.