### PR TITLE
shottimer is only displayed in coffee mode

### DIFF
--- a/rancilio-pid/display.h
+++ b/rancilio-pid/display.h
@@ -89,15 +89,18 @@
         }
         u8g2.sendBuffer();
     }
-    void displayShottimer(void) 
+    void displayShottimer(void)
      {
         displaystatus = 0 ;// Indiktator für Reset Bezug im Display
-        if 
-            ((
-            (bezugsZeit > 0 && ONLYPID == 1) || // Bezugszeit bei Only PID  
-            (ONLYPID == 0 && brewcounter > 10 && brewcounter <= 42) // oder Bezug bei nicht only PID über brewcounter
-            ) && SHOTTIMER == 1
-            ) // Shotimer muss 1 = True sein und Bezug vorliegen
+        if
+            (
+            (
+              (bezugsZeit > 0 && ONLYPID == 1) || // Bezugszeit bei Only PID
+              (ONLYPID == 0 && brewcounter > 10 && brewcounter <= 42) // oder Bezug bei nicht only PID über brewcounter
+            )
+            && Input < setPoint // Vermeidet, dass der Timer im Dampfmodus angezeigt wird indem die IST Temp kleiner als die Soll Temp sein muss
+            && SHOTTIMER == 1 // Shotimer muss 1 = True sein und Bezug vorliegen
+            )
         {
             // Dann Zeit anzeigen
             u8g2.clearBuffer();


### PR DESCRIPTION
Damit soll verhindert werden, dass der Shottimer (vor allem im SW Modus) auch beim Dampfbezug angezeigt wird