### PR TITLE
add temp window & adjust min display template

### DIFF
--- a/rancilio-pid/Displaytemplateminimal.h
+++ b/rancilio-pid/Displaytemplateminimal.h
@@ -24,27 +24,16 @@ void printScreen()
       //draw (blinking) temp
       if (fabs(Input - setPoint) < 0.3) {
         if (isrCounter < 500) {
-          if (Input < 99.999) {
             u8g2.setCursor(2, 2);
             u8g2.setFont(u8g2_font_profont22_tf);
             u8g2.print(Input, 1);
+            u8g2.setCursor(56, 6);
             u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
             u8g2.print(char(78));
-            u8g2.setCursor(78, 2);
+            u8g2.setCursor(79, 2);
             u8g2.setFont(u8g2_font_profont22_tf);
             u8g2.print(setPoint, 1);
-          }
-          else {
-            u8g2.setCursor(2, 2);
-            u8g2.setFont(u8g2_font_profont22_tf);
-            u8g2.print(Input, 0);
-            u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
-            u8g2.print(char(78));
-            u8g2.setCursor(78, 2);
-            u8g2.setFont(u8g2_font_profont22_tf);
-            u8g2.print(setPoint, 1);
-          }
-        }  
+        }
       } else {
         if (Input < 99.999) {
           u8g2.setCursor(2, 2);
@@ -63,17 +52,17 @@ void printScreen()
         } else {
           u8g2.setCursor(2, 2);
           u8g2.setFont(u8g2_font_profont22_tf);
-          u8g2.print(Input, 0);
+          u8g2.print(Input, 1);
           u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
-          u8g2.setCursor(56, 6);
+          u8g2.setCursor(72, 6);
           if (pidMode == 1) {
             u8g2.print(char(74));
           } else {
             u8g2.print(char(70));
           }
-          u8g2.setCursor(79, 2);
+          u8g2.setCursor(95, 2);
           u8g2.setFont(u8g2_font_profont22_tf);
-          u8g2.print(setPoint, 1);
+          u8g2.print(setPoint, 0);
         }
       }
 

--- a/rancilio-pid/display.h
+++ b/rancilio-pid/display.h
@@ -93,14 +93,15 @@
      {
         displaystatus = 0 ;// Indiktator für Reset Bezug im Display
         if
-            (
-            (
-              (bezugsZeit > 0 && ONLYPID == 1) || // Bezugszeit bei Only PID
-              (ONLYPID == 0 && brewcounter > 10 && brewcounter <= 42) // oder Bezug bei nicht only PID über brewcounter
-            )
-            && Input < setPoint // Vermeidet, dass der Timer im Dampfmodus angezeigt wird indem die IST Temp kleiner als die Soll Temp sein muss
-            && SHOTTIMER == 1 // Shotimer muss 1 = True sein und Bezug vorliegen
-            )
+        ((
+          (
+            (bezugsZeit > 0)
+            && (ONLYPID == 1) // Bezugszeit bei Only PID
+          )
+          || (ONLYPID == 0 && brewcounter > 10 && brewcounter <= 42) // oder Bezug bei nicht only PID über brewcounter
+        )
+        && SHOTTIMER == 1 // Shotimer muss 1 = True sein und Bezug vorliegen
+        )
         {
             // Dann Zeit anzeigen
             u8g2.clearBuffer();

--- a/rancilio-pid/display.h
+++ b/rancilio-pid/display.h
@@ -89,15 +89,18 @@
         }
         u8g2.sendBuffer();
     }
-    void displayShottimer(void) 
+    void displayShottimer(void)
      {
         displaystatus = 0 ;// Indiktator für Reset Bezug im Display
-        if 
-            ((
-            (bezugsZeit > 0 && ONLYPID == 1) || // Bezugszeit bei Only PID  
-            (ONLYPID == 0 && brewcounter > 10 && brewcounter <= 42) // oder Bezug bei nicht only PID über brewcounter
-            ) && SHOTTIMER == 1
-            ) // Shotimer muss 1 = True sein und Bezug vorliegen
+        if
+            (
+            (
+              (bezugsZeit > 0 && ONLYPID == 1) || // Bezugszeit bei Only PID
+              (ONLYPID == 0 && brewcounter > 10 && brewcounter <= 42) // oder Bezug bei nicht only PID über brewcounter
+            )
+            && Input < setPoint // Vermeidet, dass der Timer im Dampfmodus angezeigt wird indem die IST Temp kleiner als die Soll Temp sein muss
+            && SHOTTIMER == 1 // Shotimer muss 1 = True sein und Bezug vorliegen
+            )
         {
             // Dann Zeit anzeigen
             u8g2.clearBuffer();

--- a/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid.ino
@@ -964,12 +964,12 @@ void sendToBlynk() {
 /********************************************************
     Brewdetection
 ******************************************************/
-void brewdetection() 
+void brewdetection()
 {
   if (brewboarder == 0) return; //abort brewdetection if deactivated
-
-  // Brew detecion == 1 software solution , == 2 hardware == 3 Voltagesensor 
-  if (Brewdetection == 1) 
+  if ((bezugsZeit == 0) && (Input > (BrewSetPoint - 1))) return; //abort brewdetection if not in temp window
+  // Brew detecion == 1 software solution , == 2 hardware == 3 Voltagesensor
+  if (Brewdetection == 1)
   {  // Bezugstimmer für SW aktivieren
      if (timerBrewdetection == 1)
     {

--- a/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid.ino
@@ -967,7 +967,7 @@ void sendToBlynk() {
 void brewdetection()
 {
   if (brewboarder == 0) return; //abort brewdetection if deactivated
-  if ((bezugsZeit == 0) && (Input > (BrewSetPoint - 1))) return; //abort brewdetection if not in temp window
+  if ((bezugsZeit == 0) && (fabs(Input - BrewSetPoint) > 1.5)) return; //abort brewdetection if not in temp window
   // Brew detecion == 1 software solution , == 2 hardware == 3 Voltagesensor
   if (Brewdetection == 1)
   {  // Bezugstimmer für SW aktivieren

--- a/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid.ino
@@ -967,7 +967,7 @@ void sendToBlynk() {
 void brewdetection()
 {
   if (brewboarder == 0) return; //abort brewdetection if deactivated
-  if ((bezugsZeit == 0) && (fabs(Input - BrewSetPoint) > 1.5)) return; //abort brewdetection if not in temp window
+  if ((bezugsZeit == 0) && (fabs(Input - BrewSetPoint) > 2.5)) return; //abort brewdetection if not in temp window
   // Brew detecion == 1 software solution , == 2 hardware == 3 Voltagesensor
   if (Brewdetection == 1)
   {  // Bezugstimmer für SW aktivieren


### PR DESCRIPTION
Um zu vermeiden, dass der Shottimer im Dampfmodus läuft, wird dieser nur unter der Soll-Temp aktiviert.
Zudem wurde die Anzeige für das minimal Display Template angepasst, so dass die IST-Temp immer als float angezeigt wird.