### PR TITLE
adjust if condition to get correct temp window

### DIFF
--- a/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid.ino
@@ -1013,7 +1013,7 @@ void brewdetection()
 
   if (Brewdetection == 1) 
   {
-    if (heatrateaverage <= -brewboarder && timerBrewdetection == 0 && (fabs(Input - BrewSetPoint) > 2.5) ) // BD PID only +/- 2 Grad Celsius
+    if (heatrateaverage <= -brewboarder && timerBrewdetection == 0 && (fabs(Input - BrewSetPoint) < 2.5) ) // BD PID only +/- 2 Grad Celsius
     {
       DEBUG_println("SW Brew detected") ;
       timeBrewdetection = millis() ;


### PR DESCRIPTION
Aktuell wird die SW Brewdetection außerhalb es Temp Fensters ausgelöst. Die kleine Anpassung sollte abhelfen.