### PR TITLE
Not compiling when DISPLAY == 0

### DIFF
--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1839,8 +1839,8 @@ void looppid() {
               steamLogo();
             #endif
             printScreen();  // refresh display
+          }
       #endif
-      }
     //Set PID if first start of machine detected, and no SteamON
     if ((Input < BrewSetPoint) && kaltstart && SteamON == 0) {
       if (startTn != 0) {


### PR DESCRIPTION
If ´DISPLAY==0´, there is a closing brace without an opening one.