### PR TITLE
QuickMill steam-mode & enum MACHINE

### DIFF
--- a/rancilio-pid/rancilio-pid/display.h
+++ b/rancilio-pid/rancilio-pid/display.h
@@ -116,8 +116,10 @@
        void displayShottimer(void) 
      {
         displaystatus = 0 ;// Indiktator für Reset Bezug im Display
-        if ((machinestate == 30 )  && SHOTTIMER == 1)  // Shotimer muss 1 = True sein und Bezug vorliegen
+        if ( machinestate == 30 && SHOTTIMER == 1 )  // Shotimer muss 1 = True sein und Bezug vorliegen
         {
+          if ( !(machine==QuickMill && bezugsZeit < maxBrewDurationForSteamModeQM_ON) ) 
+          {
             // Dann Zeit anzeigen
             u8g2.clearBuffer();
             displaystatus = 1 ;// Indiktator für Bezug im Display
@@ -128,13 +130,16 @@
             u8g2.print(bezugsZeit / 1000, 1);
             u8g2.setFont(u8g2_font_profont11_tf);
             u8g2.sendBuffer();
-            
+          }
         }
-        if 
-        (
-        ((machinestate == 31)  &&  SHOTTIMER == 1) 
-        ) // wenn die totalbrewtime automatisch erreicht wird, soll nichts gemacht werden, da sonst falsche Zeit angezeigt wird, da Schalter später betätigt wird als totalbrewtime
+        if ( machinestate == 31  &&  SHOTTIMER == 1 ) 
         {
+        /* 
+          wenn die totalbrewtime automatisch erreicht wird, soll nichts gemacht werden, 
+          da sonst falsche Zeit angezeigt wird, da Schalter später betätigt wird als totalbrewtime
+          */
+          if( !(machine==QuickMill && lastbezugszeit < maxBrewDurationForSteamModeQM_ON) )
+          {
            displaystatus = 1 ;// Indiktator für Bezug im Display
            u8g2.clearBuffer();
            u8g2.drawXBMP(0, 0, brewlogo_width, brewlogo_height, brewlogo_bits_u8g2);
@@ -143,8 +148,9 @@
            u8g2.print(lastbezugszeit/1000, 1);
            u8g2.setFont(u8g2_font_profont11_tf);
            u8g2.sendBuffer();
-        }
-    }
+         }
+       }
+     }
       
     /********************************************************
      DISPLAY - Heatinglogo

--- a/rancilio-pid/rancilio-pid/userConfig.h
+++ b/rancilio-pid/rancilio-pid/userConfig.h
@@ -10,6 +10,15 @@
 /********************************************************
    Preconfiguration
 ******************************************************/
+
+enum MACHINE {
+	RancilioSylvia,
+	RancilioSylviaE,
+	Gaggia,
+	QuickMill
+};
+MACHINE machine = QuickMill;
+
 // Display
 #define DISPLAY 2                  // 0 = deactivated, 1 = SH1106 (e.g. 1.3 "128x64), 2 = SSD1306 (e.g. 0.96" 128x64)
 #define OLED_I2C 0x3C		           // I2C address for OLED, 0x3C by default


### PR DESCRIPTION
**QuickMill Thermoblock Dampfmodus und Aufzählung (enum) MACHINE für unterstützte Maschinen.**

Pinvoltagesensor (PVS) ON -> brew -> PVS OFF ergibt die Brühdauer _brewDuration_. Wenn die kürzer als _maxBrewDurationForSteamModeQM_ON_ = 200 ms ist, hat die Pumpe nur einen Impuls bekommen und es wird auf Dampfmodus (_steamQM_active = true_) umgeschaltet. Dann wird der PVS überwacht und gemessen, wie lange am Stück der auf OFF steht. Wenn das länger als _minPVSOffTimedForSteamModeQM_OFF_ = 1500 ms ist, kann davon ausgegangen werden, dass die pulsierende Dampfsteuerung nicht mehr läuft und der Dampfmodus wird beendet. 
In display.h wird der Shottimer erst dann angezeigt, wenn klar ist, ob es Bezug oder Dampf ist, Kriterium ist _bezugsZeit < maxBrewDurationForSteamModeQM_ON_)