### PR TITLE
Move bPID.Compute from ISR to loop

### DIFF
--- a/rancilio-pid/rancilio-pid/ISR.h
+++ b/rancilio-pid/rancilio-pid/ISR.h
@@ -1,54 +1,38 @@
 /********************************************************
-    Timer 1 - ISR for PID calculation and heat realay output
+Timer 1 - ISR for PID calculation and heat realay output
 ******************************************************/
 
+#ifdef ESP8266
+	void ICACHE_RAM_ATTR onTimer1ISR() {
+		timer1_write(6250); // set interrupt time to 20ms
 
+		if (Output <= isrCounter) {
+			digitalWrite(pinRelayHeater, LOW);
+		} else {
+			digitalWrite(pinRelayHeater, HIGH);
+		}
 
+		isrCounter += 20; // += 20 because one tick = 20ms
 
+		//set PID output as relay command
+		if (isrCounter > windowSize) {
+			isrCounter = 0;
+		}
+	}
 
+#elif defined(ESP32)
+	void IRAM_ATTR onTimer() {
+		if (Output <= isrCounter) {
+			digitalWrite(pinRelayHeater, LOW);
+		} else {
+			digitalWrite(pinRelayHeater, HIGH);
+		}
 
+		isrCounter += 10; // += 10 because one tick = 10ms
 
-#if defined(ESP8266) // ESP8266
-    
-    void ICACHE_RAM_ATTR onTimer1ISR() {
-    timer1_write(6250); // set interrupt time to 20ms
-
-    if (Output <= isrCounter) {
-        digitalWrite(pinRelayHeater, LOW);
-    } else {
-        digitalWrite(pinRelayHeater, HIGH);
-    }
-
-    isrCounter += 20; // += 20 because one tick = 20ms
-    //set PID output as relais commands
-    if (isrCounter > windowSize) {
-        isrCounter = 0;
-    }
-
-    //run PID calculation
-    bPID.Compute();
-    }
+		//set PID output as relay command
+		if (isrCounter > windowSize) {
+			isrCounter = 0;
+		}
+	}
 #endif
-
-#if defined(ESP32) // ESP32
-  void IRAM_ATTR onTimer(){
-    
-    //timer1_write(50000); // set interrupt time to 10ms
-      timerAlarmWrite(timer, 10000, true);
-    if (Output <= isrCounter) {
-      digitalWrite(pinRelayHeater, LOW);
-    } else {
-      digitalWrite(pinRelayHeater, HIGH);
-    }
-  
-    isrCounter += 10; // += 10 because one tick = 10ms
-    //set PID output as relais commands
-    if (isrCounter > windowSize) {
-      isrCounter = 0;
-    }
-  
-    //run PID calculation
-    bPID.Compute();
-  }
-
- #endif   

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1896,6 +1896,7 @@ void looppid() {
   // voids
     refreshTemp();   //read new temperature values
     testEmergencyStop();  // test if Temp is to high
+    bPID.Compute();
     #if (BREWMODE == 2 || ONLYPIDSCALE == 1 )
       checkWeight() ; // Check Weight Scale in the loop
     #endif


### PR DESCRIPTION
The ESP32 can't execute non-IRAM functions inside an ISR. It may cause the _Guru Meditation Error: Core  1 panic'ed (Cache disabled but cached memory region accessed)_. 
Therefore I would suggest to move `bPID.Compute()` from the timer ISR to the loop. `bPID.Compute()` will only change the output in intervals of windowSize = 1000ms, so the precise timing provided by the timer interrupt is not really necessary.