### PR TITLE
fix show lastbezugszeit for ONLYPIDSCALE==0

### DIFF
--- a/rancilio-pid/rancilio-pid/display.h
+++ b/rancilio-pid/rancilio-pid/display.h
@@ -134,22 +134,22 @@
             u8g2.sendBuffer();
             
         }
+        if 
+        (
+        ((machinestate == 31)  &&  SHOTTIMER == 1) 
+        ) // wenn die totalbrewtime automatisch erreicht wird, 
+          //soll nichts gemacht werden, da sonst falsche Zeit angezeigt wird, da Schalter später betätigt wird als totalbrewtime
+        {
+          displaystatus = 1 ;// Indiktator für Bezug im Display
+          u8g2.clearBuffer();
+          u8g2.drawXBMP(0, 0, brewlogo_width, brewlogo_height, brewlogo_bits_u8g2);
+          u8g2.setFont(u8g2_font_profont22_tf);
+          u8g2.setCursor(64, 25);
+          u8g2.print(lastbezugszeit/1000, 1);
+          u8g2.setFont(u8g2_font_profont11_tf);
+          u8g2.sendBuffer();
+        }
         #if ONLYPIDSCALE == 1
-          if 
-          (
-          ((machinestate == 31)  &&  SHOTTIMER == 1) 
-          ) // wenn die totalbrewtime automatisch erreicht wird, 
-            //soll nichts gemacht werden, da sonst falsche Zeit angezeigt wird, da Schalter später betätigt wird als totalbrewtime
-          {
-            displaystatus = 1 ;// Indiktator für Bezug im Display
-            u8g2.clearBuffer();
-            u8g2.drawXBMP(0, 0, brewlogo_width, brewlogo_height, brewlogo_bits_u8g2);
-            u8g2.setFont(u8g2_font_profont22_tf);
-            u8g2.setCursor(64, 25);
-            u8g2.print(lastbezugszeit/1000, 1);
-            u8g2.setFont(u8g2_font_profont11_tf);
-            u8g2.sendBuffer();
-          }
           if ((machinestate == 30 )  && SHOTTIMER == 2)  // Shotimer muss 2 sein und Bezug vorliegen
           {
               // Dann Zeit anzeigen


### PR DESCRIPTION
#if ONLYPIDSCALE == 1 wurde um einen Block nach unten gesetzt, damit die Bezugszeit am Ende des Brühens (machinestate 31) im Display angezeigt bleibt, wenn ONLYPIDSCALE = 0.