### PR TITLE
chill-mode after steam 1.0

### DIFF
--- a/rancilio-pid/rancilio-pid/Displaytemplateminimal.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplateminimal.h
@@ -8,6 +8,7 @@ void printScreen()
   (
    (machinestate == 19 || machinestate == 20 || machinestate == 35) ||
    ((machinestate == 30 || machinestate == 31)  && SHOTTIMER == 0) ||// shottimer == 0, auch Bezug anzeigen
+   machinestate == 45 ||
    ((machinestate == 10)  && HEATINGLOGO == 0) ||
    ((machinestate == 90)  && OFFLINEGLOGO == 0) 
    ) 

--- a/rancilio-pid/rancilio-pid/Displaytemplatescale.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplatescale.h
@@ -6,6 +6,7 @@ void printScreen()
   (
    (machinestate == 19 || machinestate == 20 || machinestate == 35) ||
    ((machinestate == 30 || machinestate == 31)  && SHOTTIMER == 0) ||// shottimer == 0, auch Bezug anzeigen
+   machinestate == 45 ||
    ((machinestate == 10)  && HEATINGLOGO == 0) ||
    ((machinestate == 90)  && OFFLINEGLOGO == 0) 
   ) 

--- a/rancilio-pid/rancilio-pid/Displaytemplatestandard.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplatestandard.h
@@ -12,6 +12,7 @@ void printScreen()
   (
    (machinestate == 19 || machinestate == 20 || machinestate == 35) ||
    ((machinestate == 30 || machinestate == 31)  && SHOTTIMER == 0) ||// shottimer == 0, auch Bezug anzeigen
+   machinestate == 45 ||
    ((machinestate == 10)  && HEATINGLOGO == 0) ||
    ((machinestate == 90)  && OFFLINEGLOGO == 0) 
   ) 

--- a/rancilio-pid/rancilio-pid/Displaytemplatetemponly.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplatetemponly.h
@@ -13,6 +13,7 @@ void printScreen()
   (
    (machinestate == 19 || machinestate == 20 || machinestate == 35) ||
    ((machinestate == 30 || machinestate == 31)  && SHOTTIMER == 0) ||// shottimer == 0, auch Bezug anzeigen
+   machinestate == 45 ||
    ((machinestate == 10)  && HEATINGLOGO == 0) ||
    ((machinestate == 90)  && OFFLINEGLOGO == 0)  
   ) 

--- a/rancilio-pid/rancilio-pid/Displaytemplateupright.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplateupright.h
@@ -9,6 +9,7 @@ void printScreen()
   (
    (machinestate == 19 || machinestate == 20 || machinestate == 35) ||
    ((machinestate == 30 || machinestate == 31)  && SHOTTIMER == 0) ||// shottimer == 0, auch Bezug anzeigen
+   machinestate == 45 ||
    ((machinestate == 10)  && HEATINGLOGO == 0) ||
    ((machinestate == 90)  && OFFLINEGLOGO == 0) 
   ) 


### PR DESCRIPTION
**Abkühlmodus "chill-mode after steam"**
Neuer machinestate 45 für die Abkühlphase nach dem Dampfmodus. In diesem maschinestate kann mit dem Brühschalter ein cooling flush gemacht werden (Shotcounter bleibt aus) oder mit dem Dampfschalter auf steam geschaltet werden.
Wenn bis auf Solltemperatur + 2 °C abgekühlt ist, wird in den idle-Betrieb (machinestate 20) gewechselt.

Für die QuickMill werden im machinestate 45 die PID-Werte auf Dampfeinstellungen belassen, für alle anderen Maschinen wird auf die Brüh-PID-Werte umgeschaltet.