### PR TITLE
MACHINEID

### DIFF
--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -33,6 +33,9 @@
 /********************************************************
   DEFINES
 ******************************************************/
+
+MACHINE machine = (enum MACHINE) MACHINEID;
+
 #define DEBUGMODE   // Debug mode is active if #define DEBUGMODE is set
 
 //#define BLYNK_PRINT Serial    // In detail debugging for blynk

--- a/rancilio-pid/rancilio-pid/userConfig_sample.h
+++ b/rancilio-pid/rancilio-pid/userConfig_sample.h
@@ -11,21 +11,20 @@
 #ifndef _userConfig_H
 #define _userConfig_H  
 
-// MACHINE 
+// List of supported machines
 enum MACHINE {
-	RancilioSilvia,
-	RancilioSilviaE,
-	Gaggia,
-	QuickMill
+  RancilioSilvia,   // MACHINEID 0
+  RancilioSilviaE,  // MACHINEID 1
+  Gaggia,           // MACHINEID 2
+  QuickMill         // MACHINEID 3
 };
-
 
 /********************************************************
    Preconfiguration
 ******************************************************/
 
-// MACHINETYPE, use the exakt name of the machine 
-MACHINE machine = RancilioSilvia;      //	RancilioSilvia, RancilioSilviaE, Gaggia, QuickMill
+// Machine 
+#define MACHINEID 0                //	see above list of supported machines
 
 // Display
 #define DISPLAY 2                  // 0 = deactivated, 1 = SH1106 (e.g. 1.3 "128x64), 2 = SSD1306 (e.g. 0.96" 128x64)


### PR DESCRIPTION
**Status Quo**
Im Zuge der Anpassungen an die Quick Mill Thermoblock Maschinen wurde in der userConfig.h ein enum MACHINES mit den Maschinennamen eingeführt. Der verwendete Maschinentyp wird in der Variable machine zugewiesen (Definition).

**Problem**
Durch diese in der userConfig.h enthaltenden Definition ist es nicht mehr möglich, die userConfig.h von verschiedenen Programmteilen (in verschiedenen Übersetzungseinheiten) aus einzubinden, da spätestens beim Linken das Verletzen der "one definition rule" zu einem Fehler führt. 

**Lösung**
Zur Abhilfe schlage ich vor, eine MACHINEID einzuführen und basierend auf dieser die Definition in ranicilio-pid.ino zu verschieben. 
