### PR TITLE
Update platformio.ini to circumvent problem with espressif version 3.x

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -3,13 +3,13 @@ lib_dir = rancilio-pid/libraries/
 src_dir = rancilio-pid/rancilio-pid/
 
 [env:nodemcuv2_usb]
-platform = espressif8266
+platform = espressif8266@^2.6.3
 board = nodemcuv2
 framework = arduino
 monitor_speed = 115200
 
 [env:nodemcuv2_ota]
-platform = espressif8266
+platform = espressif8266@^2.6.3
 board = nodemcuv2
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
force platform to version 2.6.3 because 3.x won't compile