### PR TITLE
add missing break statement

### DIFF
--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1311,6 +1311,7 @@ void machinestatevoid()
       {
         machinestate = 100 ;// sensorerror
       }
+      break;
       // Setpoint -1 Celsius
       case 19: 
       if (Input >= (BrewSetPoint))


### PR DESCRIPTION
without this we *will* run into case `19` after e.g. evaluating the steamOn, pidOn or sensorError conditions -- this has caused trouble on a separate feature I worked on.