### PR TITLE
don't get stuck in sensor error

### DIFF
--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1633,6 +1633,10 @@ void machinestatevoid()
 
     case kSensorError:
       machinestate = kSensorError ;
+      if (!sensorError)
+      {
+          machinestate = kInit;
+      }
     break;
   } // switch case
 


### PR DESCRIPTION
If we ever entered the sensor error state we were unable to exit it. With this change we will exit the state and begin init again once the error condition has resolved.