### PR TITLE
fix compiler warnings (incl. buffer overflow)

### DIFF
--- a/rancilio-pid/libraries/Blynk/src/BlynkSimpleEsp8266.h
+++ b/rancilio-pid/libraries/Blynk/src/BlynkSimpleEsp8266.h
@@ -50,7 +50,8 @@ public:
             BlynkDelay(500);
         }
         BLYNK_LOG1(BLYNK_F("Connected to WiFi"));
-        BLYNK_LOG_IP("IP: ", WiFi.localIP());
+        IPAddress myip = WiFi.localIP();
+        BLYNK_LOG_IP("IP: ", myip);
     }
 
     void config(const char* auth,

--- a/rancilio-pid/libraries/Blynk/src/BlynkSimpleEsp8266.h
+++ b/rancilio-pid/libraries/Blynk/src/BlynkSimpleEsp8266.h
@@ -50,9 +50,7 @@ public:
             BlynkDelay(500);
         }
         BLYNK_LOG1(BLYNK_F("Connected to WiFi"));
-
-        IPAddress myip = WiFi.localIP();
-        BLYNK_LOG_IP("IP: ", myip);
+        BLYNK_LOG_IP("IP: ", WiFi.localIP());
     }
 
     void config(const char* auth,

--- a/rancilio-pid/libraries/ZACwire-Library-1.3.0/ZACwire.h
+++ b/rancilio-pid/libraries/ZACwire-Library-1.3.0/ZACwire.h
@@ -113,7 +113,10 @@ class ZACwire {
 				ByteNr = 1;
 				rawTemp[1][backUP] = 0;
 			}
-			else if (BitCounter == 6) ByteNr = rawTemp[0][backUP] = 0;
+			else if (BitCounter == 6) {
+        ByteNr = 0;
+        rawTemp[0][backUP] = 0;
+      }
 			 
 			rawTemp[ByteNr][backUP] <<= 1;      
 			if (deltaTime > bitWindow);				//Logic 0

--- a/rancilio-pid/rancilio-pid/Displayrotateupright.h
+++ b/rancilio-pid/rancilio-pid/Displayrotateupright.h
@@ -71,6 +71,7 @@ void displayLogo(String displaymessagetext, String displaymessagetext2)
     u8g2.sendBuffer();
 }
 
+#if 0 //not used a.t.m.
 /********************************************************
  DISPLAY - EmergencyStop
 *****************************************************/
@@ -97,6 +98,7 @@ void displayEmergencyStop(void)
     }
     u8g2.sendBuffer();
 }
+#endif
 
 
 /********************************************************
@@ -134,15 +136,4 @@ void displayShottimer(void)
        u8g2.setFont(u8g2_font_profont11_tf);
        u8g2.sendBuffer();
     }
-}    void OFFlogo(void) 
-    {
-     if (OFFLINEGLOGO == 1 && pidON == 0) 
-     {
-       u8g2.clearBuffer();
-       u8g2.drawXBMP(0,0, OFFLogo_width, OFFLogo_height, OFFLogo); 
-       u8g2.setCursor(0, 70);
-       u8g2.setFont(u8g2_font_profont10_tf);
-       u8g2.print("PID OFFLINE");   
-       u8g2.sendBuffer();
-     }
-    }
+}

--- a/rancilio-pid/rancilio-pid/Displaytemplateminimal.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplateminimal.h
@@ -3,7 +3,6 @@
 ******************************************************/
 void printScreen()
 {
-    unsigned long currentMillisDisplay = millis();
     if (
         (machinestate == kSetPointNegative || machinestate == kPidNormal || machinestate == kBrewDetectionTrailing) ||
         ((machinestate == kBrew || machinestate == kShotTimerAfterBrew) && SHOTTIMER == 0) || // shottimer == 0, auch Bezug anzeigen

--- a/rancilio-pid/rancilio-pid/Displaytemplatescale.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplatescale.h
@@ -1,7 +1,5 @@
 void printScreen() 
 {
-
-  unsigned long currentMillisDisplay = millis();
   if 
   (
    (machinestate == kSetPointNegative || machinestate == kPidNormal || machinestate == kBrewDetectionTrailing) ||

--- a/rancilio-pid/rancilio-pid/Displaytemplatestandard.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplatestandard.h
@@ -6,8 +6,6 @@
 
 void printScreen() 
 {
-
-  unsigned long currentMillisDisplay = millis();
   if 
   (
    (machinestate == kSetPointNegative || machinestate == kPidNormal || machinestate == kBrewDetectionTrailing) ||

--- a/rancilio-pid/rancilio-pid/Displaytemplatetemponly.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplatetemponly.h
@@ -7,8 +7,6 @@ float blinkingtempoffset = 0.3; // offset for blinking
 
 void printScreen() 
 {
-
-  unsigned long currentMillisDisplay = millis();
   if
   (
    (machinestate == kSetPointNegative || machinestate == kPidNormal || machinestate == kBrewDetectionTrailing) ||

--- a/rancilio-pid/rancilio-pid/Displaytemplateupright.h
+++ b/rancilio-pid/rancilio-pid/Displaytemplateupright.h
@@ -3,8 +3,6 @@
 ******************************************************/
 void printScreen() 
 {
-  
-  unsigned long currentMillisDisplay = millis();
   if  
   (
    (machinestate == kSetPointNegative || machinestate == kPidNormal || machinestate == kBrewDetectionTrailing) ||

--- a/rancilio-pid/rancilio-pid/brewvoid.h
+++ b/rancilio-pid/rancilio-pid/brewvoid.h
@@ -143,7 +143,6 @@ void backflush()
   digitalWrite(pinRelayHeater, LOW); //Stop heating
   
   checkbrewswitch() ;
-  unsigned long currentMillistemp = millis();
 
   if (brewswitch == LOW && backflushState > 10) {   //abort function for state machine from every state
     backflushState = 43;
@@ -190,7 +189,6 @@ void backflush()
         debugStream.writeI("backflush finished");
         digitalWrite(pinRelayVentil, relayOFF);
         digitalWrite(pinRelayPumpe, relayOFF);
-        currentMillistemp = 0;
         flushCycles = 0;
         backflushState = 10;
       }

--- a/rancilio-pid/rancilio-pid/languages.h
+++ b/rancilio-pid/rancilio-pid/languages.h
@@ -2,9 +2,11 @@
 static const char *langstring_set_temp =      "Soll:  ";
 static const char *langstring_current_temp =  "Ist:   ";
 static const char *langstring_brew =          "Brew:  ";
+#if (DISPLAYTEMPLATE >= 20)  //vertical templates
 static const char *langstring_set_temp_rot_ur =      "S: ";
 static const char *langstring_current_temp_rot_ur =  "I: ";
 static const char *langstring_brew_rot_ur =          "B: ";
+#endif
 static const char *langstring_offlinemod =    "Offlinemodus";
 static const char *langstring_wasserleer =    "Wasser leer";
 
@@ -16,6 +18,7 @@ static const char *langstring_connectblynk2[] =  {"3: Blynk connected", "sync al
 static const char *langstring_nowifi[] = {"No ", "WIFI"};
 
 static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. Sensor!"};
+// static const char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
 
 static const char *langstring_bckffinished[] = {"Backflush finished", "Please reset brewswitch..."};
 static const char *langstring_bckfactivated[] = {"Backflush activated", "Please set brewswitch..."};
@@ -25,9 +28,11 @@ static const char *langstring_bckfrunning[] = {"Backflush running:", "from"};
 static const char *langstring_set_temp =      "Set:   ";
 static const char *langstring_current_temp =  "Temp:  ";
 static const char *langstring_brew =          "Brew:  ";
+#if (DISPLAYTEMPLATE >= 20)  //vertical templates
 static const char *langstring_set_temp_rot_ur =      "S: ";
 static const char *langstring_current_temp_rot_ur =  "T: ";
 static const char *langstring_brew_rot_ur =          "B: ";
+#endif
 static const char *langstring_offlinemod =    "Offline mode";
 static const char *langstring_wasserleer =    "Empty water";
 
@@ -39,6 +44,7 @@ static const char *langstring_connectblynk2[] =  {"3: Blynk connected", "sync al
 static const char *langstring_nowifi[] = {"No ", "WIFI"};
 
 static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. Sensor!"};
+// static const char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
 
 static const char *langstring_bckffinished[] = {"Backflush finished", "Please reset brewswitch..."};
 static const char *langstring_bckfactivated[] = {"Backflush activated", "Please set brewswitch..."};
@@ -48,9 +54,11 @@ static const char *langstring_bckfrunning[] = {"Backflush running:", "from"};
 static const char *langstring_set_temp =      "Obj:  ";
 static const char *langstring_current_temp =  "T:    ";
 static const char *langstring_brew =          "Brew:  ";
+#if (DISPLAYTEMPLATE >= 20)  //vertical templates
 static const char *langstring_set_temp_rot_ur =      "O: ";
 static const char *langstring_current_temp_rot_ur =  "T: ";
 static const char *langstring_brew_rot_ur =          "B: ";
+#endif
 static const char *langstring_offlinemod =    "Modo offline";
 static const char *langstring_wasserleer =    "Agua vacía";
 
@@ -62,6 +70,7 @@ static const char *langstring_connectblynk2[] =  {"3: Conect. a Blynk", "sincron
 static const char *langstring_nowifi[] = {"No ", "WIFI"};
 
 static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Comprueba sensor T!"};
+// static const char *langstring_emergencyStop[] = {"CALENT.", "PARADO "};
 
 static const char *langstring_bckffinished[] = {"Backflush terminado", "Apague el boton de cafe..."};
 static const char *langstring_bckfactivated[] = {"Backflush activado ", "Encienda boton de cafe.."};

--- a/rancilio-pid/rancilio-pid/languages.h
+++ b/rancilio-pid/rancilio-pid/languages.h
@@ -1,75 +1,69 @@
 #if  LANGUAGE == 0 // DE
-static char *langstring_set_temp =      "Soll:  ";
-static char *langstring_current_temp =  "Ist:   ";
-static char *langstring_brew =          "Brew:  ";
-static char *langstring_set_temp_rot_ur =      "S: ";
-static char *langstring_current_temp_rot_ur =  "I: ";
-static char *langstring_brew_rot_ur =          "B: ";
+static const char *langstring_set_temp =      "Soll:  ";
+static const char *langstring_current_temp =  "Ist:   ";
+static const char *langstring_brew =          "Brew:  ";
+static const char *langstring_set_temp_rot_ur =      "S: ";
+static const char *langstring_current_temp_rot_ur =  "I: ";
+static const char *langstring_brew_rot_ur =          "B: ";
+static const char *langstring_offlinemod =    "Offlinemodus";
+static const char *langstring_wasserleer =    "Wasser leer";
 
-static char *langstring_offlinemod =    "Offlinemodus";
-static char *langstring_wasserleer =    "Wasser leer";
+static const char *langstring_wifirecon =     "Wifi reconnect:";
+static const char *langstring_connectwifi1 =  "1: Connect Wifi to:";
+static const char *langstring_connectwifi2[] =  {"2: Wifi connected, ", "try Blynk   "};
+static const char *langstring_connectblynk1[] =  {"Connect to Blynk", "no Fallback"};
+static const char *langstring_connectblynk2[] =  {"3: Blynk connected", "sync all variables..."};
+static const char *langstring_nowifi[] = {"No ", "WIFI"};
 
-static char *langstring_wifirecon =     "Wifi reconnect:";
-static char *langstring_connectwifi1 =  "1: Connect Wifi to:";
-static char *langstring_connectwifi2[] =  {"2: Wifi connected, ", "try Blynk   "};
-static char *langstring_connectblynk1[] =  {"Connect to Blynk", "no Fallback"};
-static char *langstring_connectblynk2[] =  {"3: Blynk connected", "sync all variables..."};
-static char *langstring_nowifi[] = {"No ", "WIFI"};
+static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. Sensor!"};
 
-static char *langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. Sensor!"};
-static char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
-
-static char *langstring_bckffinished[] = {"Backflush finished", "Please reset brewswitch..."};
-static char *langstring_bckfactivated[] = {"Backflush activated", "Please set brewswitch..."};
-static char *langstring_bckfrunning[] = {"Backflush running:", "from"};
+static const char *langstring_bckffinished[] = {"Backflush finished", "Please reset brewswitch..."};
+static const char *langstring_bckfactivated[] = {"Backflush activated", "Please set brewswitch..."};
+static const char *langstring_bckfrunning[] = {"Backflush running:", "from"};
 
 #elif LANGUAGE == 1 // EN
-static char *langstring_set_temp =      "Set:   ";
-static char *langstring_current_temp =  "Temp:  ";
-static char *langstring_brew =          "Brew:  ";
-static char *langstring_set_temp_rot_ur =      "S: ";
-static char *langstring_current_temp_rot_ur =  "T: ";
-static char *langstring_brew_rot_ur =          "B: ";
+static const char *langstring_set_temp =      "Set:   ";
+static const char *langstring_current_temp =  "Temp:  ";
+static const char *langstring_brew =          "Brew:  ";
+static const char *langstring_set_temp_rot_ur =      "S: ";
+static const char *langstring_current_temp_rot_ur =  "T: ";
+static const char *langstring_brew_rot_ur =          "B: ";
+static const char *langstring_offlinemod =    "Offline mode";
+static const char *langstring_wasserleer =    "Empty water";
 
-static char *langstring_offlinemod =    "Offline mode";
-static char *langstring_wasserleer =    "Empty water";
+static const char *langstring_wifirecon =     "Wifi reconnect:";
+static const char *langstring_connectwifi1 =  "1: Connect Wifi to:";
+static const char *langstring_connectwifi2[] =  {"2: Wifi connected, ", "try Blynk   "};
+static const char *langstring_connectblynk1[] =  {"Connect to Blynk", "no Fallback"};
+static const char *langstring_connectblynk2[] =  {"3: Blynk connected", "sync all variables..."};
+static const char *langstring_nowifi[] = {"No ", "WIFI"};
 
-static char *langstring_wifirecon =     "Wifi reconnect:";
-static char *langstring_connectwifi1 =  "1: Connect Wifi to:";
-static char *langstring_connectwifi2[] =  {"2: Wifi connected, ", "try Blynk   "};
-static char *langstring_connectblynk1[] =  {"Connect to Blynk", "no Fallback"};
-static char *langstring_connectblynk2[] =  {"3: Blynk connected", "sync all variables..."};
-static char *langstring_nowifi[] = {"No ", "WIFI"};
+static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. Sensor!"};
 
-static char *langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. Sensor!"};
-static char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
-
-static char *langstring_bckffinished[] = {"Backflush finished", "Please reset brewswitch..."};
-static char *langstring_bckfactivated[] = {"Backflush activated", "Please set brewswitch..."};
-static char *langstring_bckfrunning[] = {"Backflush running:", "from"};
+static const char *langstring_bckffinished[] = {"Backflush finished", "Please reset brewswitch..."};
+static const char *langstring_bckfactivated[] = {"Backflush activated", "Please set brewswitch..."};
+static const char *langstring_bckfrunning[] = {"Backflush running:", "from"};
 
 #elif LANGUAGE == 2 // ES
-static char *langstring_set_temp =      "Obj:  ";
-static char *langstring_current_temp =  "T:    ";
-static char *langstring_brew =          "Brew:  ";
-static char *langstring_set_temp_rot_ur =      "O: ";
-static char *langstring_current_temp_rot_ur =  "T: ";
-static char *langstring_brew_rot_ur =          "B: ";
+static const char *langstring_set_temp =      "Obj:  ";
+static const char *langstring_current_temp =  "T:    ";
+static const char *langstring_brew =          "Brew:  ";
+static const char *langstring_set_temp_rot_ur =      "O: ";
+static const char *langstring_current_temp_rot_ur =  "T: ";
+static const char *langstring_brew_rot_ur =          "B: ";
+static const char *langstring_offlinemod =    "Modo offline";
+static const char *langstring_wasserleer =    "Agua vacía";
 
-static char *langstring_offlinemod =    "Modo offline";
-static char *langstring_wasserleer =    "Agua vacía";
+static const char *langstring_wifirecon =     "Reconecta wifi:";
+static const char *langstring_connectwifi1 =  "1: Wifi conectado :";
+static const char *langstring_connectwifi2[] =  {"2: Wifi conectado, ", "proba. Blynk"};
+static const char *langstring_connectblynk1[] =  {"Conect. a Blynk ", "no Fallback"};
+static const char *langstring_connectblynk2[] =  {"3: Conect. a Blynk", "sincron. variables..."};
+static const char *langstring_nowifi[] = {"No ", "WIFI"};
 
-static char *langstring_wifirecon =     "Reconecta wifi:";
-static char *langstring_connectwifi1 =  "1: Wifi conectado :";
-static char *langstring_connectwifi2[] =  {"2: Wifi conectado, ", "proba. Blynk"};
-static char *langstring_connectblynk1[] =  {"Conect. a Blynk ", "no Fallback"};
-static char *langstring_connectblynk2[] =  {"3: Conect. a Blynk", "sincron. variables..."};
-static char *langstring_nowifi[] = {"No ", "WIFI"};
+static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Comprueba sensor T!"};
 
-static char *langstring_error_tsensor[] = {"Error, Temp: ", "Comprueba sensor T!"};
-static char *langstring_emergencyStop[] = {"CALENT.", "PARADO "};
-
-static char *langstring_bckffinished[] = {"Backflush terminado", "Apague el boton de cafe..."};
-static char *langstring_bckfactivated[] = {"Backflush activado ", "Encienda boton de cafe.."};
-static char *langstring_bckfrunning[] = {"Backflush activo: ", "desde"};
+static const char *langstring_bckffinished[] = {"Backflush terminado", "Apague el boton de cafe..."};
+static const char *langstring_bckfactivated[] = {"Backflush activado ", "Encienda boton de cafe.."};
+static const char *langstring_bckfrunning[] = {"Backflush activo: ", "desde"};
 #endif

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1047,7 +1047,7 @@ int filter(int input) {
 
 
 void mqtt_callback(char* topic, byte* data, unsigned int length) {
-  char topic_str[255];
+  char topic_str[256];
   os_memcpy(topic_str, topic, sizeof(topic_str));
   topic_str[255] = '\0';
   char data_str[length+1];

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -807,7 +807,7 @@ char* number2string(unsigned int in) {
 /*******************************************************
    Publish Data to MQTT
 *****************************************************/
-bool mqtt_publish(char *reading, char *payload)
+bool mqtt_publish(const char *reading, char *payload)
 {
 #if MQTT
     char topic[120];

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -826,7 +826,6 @@ void sendToBlynk() {
   if (Offlinemodus == 1) return;
 
   unsigned long currentMillisBlynk = millis();
-  unsigned long currentMillistemp = 0;
 
   if (currentMillisBlynk - previousMillisBlynk >= intervalBlynk) {
 
@@ -1057,9 +1056,6 @@ void mqtt_callback(char* topic, byte* data, unsigned int length) {
   char configVar[120];
   char cmd[64];
   double data_double;
-  int data_int;
-
-
 
  // DEBUG_print("mqtt_parse(%s, %s)\n", topic_str, data_str);
   snprintf(topic_pattern, sizeof(topic_pattern), "%s%s/%%[^\\/]/%%[^\\/]", mqtt_topic_prefix, hostname);

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -323,11 +323,11 @@ void getSignalStrength() {
 
   if (rssi >= -50) {
     bars = 4;
-  } else if (rssi < -50 & rssi >= -65) {
+  } else if (rssi < -50 && rssi >= -65) {
     bars = 3;
-  } else if (rssi < -65 & rssi >= -75) {
+  } else if (rssi < -65 && rssi >= -75) {
     bars = 2;
-  } else if (rssi < -75 & rssi >= -80) {
+  } else if (rssi < -75 && rssi >= -80) {
     bars = 1;
   } else {
     bars = 0;


### PR DESCRIPTION
Fixed a lot of compiler warnings (including a critical buffer overflow).
There are still some warnings left which should be discussed, for example:
- userConfig.h:30:0: warning: "DISPLAY" redefined
- libraries/ZACwire-Library-1.3.0/ZACwire.h:47:68: warning: suggest parentheses around '+' inside '>>' [-Wparentheses]