### PR TITLE
cleaned up timer1 handling (always enable with same settings)

### DIFF
--- a/rancilio-pid/rancilio-pid/ISR.h
+++ b/rancilio-pid/rancilio-pid/ISR.h
@@ -2,7 +2,7 @@
     Timer 1 - ISR for PID calculation and heat realay output
 ******************************************************/
 
-
+#include <Arduino.h>
 
 
 
@@ -52,3 +52,64 @@
   }
 
  #endif   
+
+
+void initTimer1(void)
+{
+  #if defined(ESP8266)
+  /********************************************************
+    Timer1 ISR - Initialisierung
+    TIM_DIV1 = 0,   //80MHz (80 ticks/us - 104857.588 us max)
+    TIM_DIV16 = 1,  //5MHz (5 ticks/us - 1677721.4 us max)
+    TIM_DIV256 = 3  //312.5Khz (1 tick = 3.2us - 26843542.4 us max)
+  ******************************************************/
+  timer1_isr_init();
+  timer1_attachInterrupt(onTimer1ISR);
+  //timer1_write(50000); // DIV16: set interrupt time to 10ms
+  timer1_write(6250); // DIV256: set interrupt time to 20ms
+  #elif defined(ESP32) // ESP32
+  /********************************************************
+    Timer1 ISR - Initialisierung
+    TIM_DIV1 = 0,   //80MHz (80 ticks/us - 104857.588 us max)
+    TIM_DIV16 = 1,  //5MHz (5 ticks/us - 1677721.4 us max)
+    TIM_DIV256 = 3  //312.5Khz (1 tick = 3.2us - 26843542.4 us max)
+  ******************************************************/
+  timer = timerBegin(0, 80, true); //m
+  timerAttachInterrupt(timer, &onTimer, true);//m
+  timerAlarmWrite(timer, 10000, true);//m
+  #else
+  #error("not supported MCU");
+  #endif
+}
+
+
+
+void enableTimer1(void)
+{
+  #if defined(ESP8266)
+  //timer1_enable(TIM_DIV16, TIM_EDGE, TIM_SINGLE);
+  timer1_enable(TIM_DIV256, TIM_EDGE, TIM_SINGLE);
+  #elif defined(ESP32) // ESP32
+  timerAlarmEnable(timer);
+  #else
+  #error("not supported MCU");
+  #endif
+}
+
+
+void disableTimer1(void)
+{
+  #if defined(ESP8266)
+  timer1_disable();
+  #elif defined(ESP32) // ESP32
+  timerAlarmDisable(timer);
+  #else
+  #error("not supported MCU");
+  #endif
+}
+
+
+bool isTimer1Enabled(void)
+{
+  return ((T1C & (1 << TCTE)) != 0);
+}

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1973,32 +1973,8 @@ void setup() {
   #endif
   setupDone = true;
 
-  #if defined(ESP8266) 
-    /********************************************************
-      Timer1 ISR - Initialisierung
-      TIM_DIV1 = 0,   //80MHz (80 ticks/us - 104857.588 us max)
-      TIM_DIV16 = 1,  //5MHz (5 ticks/us - 1677721.4 us max)
-      TIM_DIV256 = 3  //312.5Khz (1 tick = 3.2us - 26843542.4 us max)
-    ******************************************************/
-      timer1_isr_init();
-      timer1_attachInterrupt(onTimer1ISR);
-      //timer1_enable(TIM_DIV16, TIM_EDGE, TIM_SINGLE);
-      //timer1_write(50000); // set interrupt time to 10ms
-      timer1_enable(TIM_DIV256, TIM_EDGE, TIM_SINGLE);
-      timer1_write(6250); // set interrupt time to 20ms
-  #endif
-  #if defined(ESP32) // ESP32
-        /********************************************************
-    Timer1 ISR - Initialisierung
-    TIM_DIV1 = 0,   //80MHz (80 ticks/us - 104857.588 us max)
-    TIM_DIV16 = 1,  //5MHz (5 ticks/us - 1677721.4 us max)
-    TIM_DIV256 = 3  //312.5Khz (1 tick = 3.2us - 26843542.4 us max)
-  ******************************************************/
-    timer = timerBegin(0, 80, true); //m
-    timerAttachInterrupt(timer, &onTimer, true);//m
-    timerAlarmWrite(timer, 10000, true);//m
-    timerAlarmEnable(timer);//m
-  #endif
+  initTimer1();
+  enableTimer1();
 }
 
 void loop() {
@@ -2065,33 +2041,17 @@ void looppid()
     // Disable interrupt it OTA is starting, otherwise it will not work
     ArduinoOTA.onStart([]() 
     {
-      
-      #if defined(ESP8266) 
-      timer1_disable();
-      #endif
-      #if defined(ESP32) 
-      timerAlarmDisable(timer);
-      #endif
+      disableTimer1();
       digitalWrite(pinRelayHeater, LOW); //Stop heating
     });
     ArduinoOTA.onError([](ota_error_t error) 
     {
-      #if defined(ESP8266) 
-      timer1_enable(TIM_DIV16, TIM_EDGE, TIM_SINGLE);
-      #endif
-      #if defined(ESP32) 
-      timerAlarmEnable(timer);
-      #endif
+      enableTimer1();
     });
     // Enable interrupts if OTA is finished
     ArduinoOTA.onEnd([]() 
     {
-      #if defined(ESP8266) 
-       timer1_enable(TIM_DIV16, TIM_EDGE, TIM_SINGLE);
-      #endif
-      #if defined(ESP32)
-        timerAlarmEnable(timer);
-      #endif
+      enableTimer1();
     });
 
     if (Blynk.connected()) 


### PR DESCRIPTION
Dieser Patch behebt die falsche Konfiguration des Timer1 nach einem OTA-Prozess (TIM_DIV16 statt TIM_DIV256).
Zur besseren Handhabung und um zukünftige Inkonsistenzen zu vermeiden, habe ich Funktionen zum Initialisieren, Aus- und Einschalten des Timer1 angelegt. Dadurch wird z. B. auch die Unterscheidung zw. ESP8266 u. ESP32 an zentralen Stellen erledigt. Die Funktionen werden jetzt an den entspr. Code-Stellen verwendet.