### PR TITLE
cleanup EEPROM access

### DIFF
--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -674,7 +674,6 @@ void initOfflineMode()
   debugStream.writeI("Start offline mode with eeprom values, no wifi:(");
   Offlinemodus = 1 ;
 
-  EEPROM.begin(1024);  // open eeprom
   double dummy; // check if eeprom values are numeric (only check first value in eeprom)
   EEPROM.get(0, dummy);
   debugStream.writeI("check eeprom 0x00 in dummy: %f",dummy);
@@ -1651,6 +1650,8 @@ void setup() {
   DEBUGSTART(115200);
   debugStream.setup();
 
+  EEPROM.begin(1024);
+
   if (MQTT == 1) {
     //MQTT
     snprintf(topic_will, sizeof(topic_will), "%s%s/%s", mqtt_topic_prefix, hostname, "will");
@@ -1834,8 +1835,6 @@ void setup() {
           Blynk.syncVirtual(V34);
           // Blynk.syncAll();  //sync all values from Blynk server
           // Werte in den eeprom schreiben
-          // ini eeprom mit begin
-          EEPROM.begin(1024);
           EEPROM.put(0, aggKp);
           EEPROM.put(10, aggTn);
           EEPROM.put(20, aggTv);  
@@ -1854,7 +1853,6 @@ void setup() {
       } else 
       {
         debugStream.writeI("No connection to Blynk");
-        EEPROM.begin(1024);  // open eeprom
         double dummy; // check if eeprom values are numeric (only check first value in eeprom)
         EEPROM.get(0, dummy);
         debugStream.writeI("check eeprom 0x00 in dummy: %f",dummy);


### PR DESCRIPTION
Diese Patch-Serie beinhaltet folgende Änderungen:
- zentrale Initialisierung des EEPROMs
- EEPROM-Funktionen zum Lesen/Schreiben der Systemparameter-Werte
Die Funktionen vereinheitlichen den Zugriff auf die Systemparameter-Werte im EEPROM. Beim Schreiben wird außerdem der Timer1-Interrupt behandelt. Die Funktionen dienen auch als Vorbereitung für das neue Feature "Display Menu", über das ebenfalls auf das EEPROM zugegriffen werden kann.
Da ich die Blynk-App nicht nutze, konnte ich die Änderungen nur in Verbindung mit dem Display-Menü testen (Lesen/Schreiben der Systemparameter-Werte).