### PR TITLE
Moved sysversion to config file

### DIFF
--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -186,7 +186,7 @@ int relayON, relayOFF;          // used for relay trigger type. Do not change!
 boolean kaltstart = true;       // true = Rancilio started for first time
 boolean emergencyStop = false;  // Notstop bei zu hoher Temperatur
 double EmergencyStopTemp = 120; // Temp EmergencyStopTemp
-const char* sysVersion PROGMEM  = "Version 2.9.3 MASTER";   //System version
+const char* sysVersion PROGMEM  = SYSVERSION; //"Version 2.9.3 MASTER";   //System version
 int inX = 0, inY = 0, inOld = 0, inSum = 0; //used for filter()
 int bars = 0; //used for getSignalStrength()
 boolean brewDetected = 0;

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1,6 +1,7 @@
 /********************************************************
-   Version 2.9.3 (03.07.2021)  
+   Version 2.9.4 (07.01.2022)     
 ******************************************************/
+#define  SYSVERSION_INO '2.9.4 MASTER'
 
 /********************************************************
   INCLUDES
@@ -28,6 +29,13 @@
 
 #if (BREWMODE == 2 || ONLYPIDSCALE == 1)
 #include <HX711_ADC.h>
+#endif
+
+/********************************************************
+  Version of userConfig and rancilio-pid.ino need to match
+******************************************************/
+#if !defined(SYSVERSION) || !defined(SYSVERSION_INO)  || (SYSVERSION != SYSVERSION_INO)
+  #error Version of userConfig file and rancilio-pid.ino need to match!
 #endif
 
 /********************************************************
@@ -100,6 +108,7 @@ const unsigned int maxWifiReconnects = MAXWIFIRECONNECTS;
 //int machineLogo = MACHINELOGO;
 const unsigned long brewswitchDelay = BREWSWITCHDELAY;
 int BrewMode = BREWMODE;
+const char* sysVersion PROGMEM  = "Version " + SYSVERSION; //System version
 
 //Display
 uint8_t oled_i2c = OLED_I2C;
@@ -186,7 +195,6 @@ int relayON, relayOFF;          // used for relay trigger type. Do not change!
 boolean kaltstart = true;       // true = Rancilio started for first time
 boolean emergencyStop = false;  // Notstop bei zu hoher Temperatur
 double EmergencyStopTemp = 120; // Temp EmergencyStopTemp
-const char* sysVersion PROGMEM  = SYSVERSION; //"Version 2.9.3 MASTER";   //System version
 int inX = 0, inY = 0, inOld = 0, inSum = 0; //used for filter()
 int bars = 0; //used for getSignalStrength()
 boolean brewDetected = 0;

--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -1,7 +1,10 @@
 /********************************************************
-   Version 2.9.4 (07.01.2022)     
+   Version 2.9.4 (10.01.2022)     
 ******************************************************/
+
+// SYSVERSION and SYSVERSION_INO need to match, checked by preprocessor
 #define  SYSVERSION_INO '2.9.4 MASTER'
+#define  SYSVERSION_DISPLAY "Version 2.9.4 MASTER"  // Displayed during startup
 
 /********************************************************
   INCLUDES
@@ -108,7 +111,7 @@ const unsigned int maxWifiReconnects = MAXWIFIRECONNECTS;
 //int machineLogo = MACHINELOGO;
 const unsigned long brewswitchDelay = BREWSWITCHDELAY;
 int BrewMode = BREWMODE;
-const char* sysVersion PROGMEM  = "Version " + SYSVERSION; //System version
+const char* sysVersion PROGMEM  = SYSVERSION_DISPLAY; //System version
 
 //Display
 uint8_t oled_i2c = OLED_I2C;

--- a/rancilio-pid/rancilio-pid/userConfig_sample.h
+++ b/rancilio-pid/rancilio-pid/userConfig_sample.h
@@ -10,7 +10,7 @@
 #ifndef _userConfig_H
 #define _userConfig_H  
 
-#define SYSVERSION "Version 2.9.4 MASTER"
+#define SYSVERSION '2.9.4 MASTER'
 
 // List of supported machines
 enum MACHINE {

--- a/rancilio-pid/rancilio-pid/userConfig_sample.h
+++ b/rancilio-pid/rancilio-pid/userConfig_sample.h
@@ -1,6 +1,5 @@
 /********************************************************
-  Version 2.5 (20.05.2021) 
-  Last Change: PINPRESSURESENSOR
+  Version 2.9.4 (07.01.2022) 
   Values must be configured by the user
 ******************************************************/
 
@@ -10,6 +9,8 @@
 
 #ifndef _userConfig_H
 #define _userConfig_H  
+
+#define SYSVERSION "Version 2.9.4 MASTER"
 
 // List of supported machines
 enum MACHINE {


### PR DESCRIPTION
Moving the version number from rancilio-pid.ino to userConfig should make it easier to update it. This value gets displayed during startup (and is incorrect in the current release)