### PR TITLE
machine state check on outer if

### DIFF
--- a/rancilio-pid/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid/rancilio-pid.ino
@@ -882,14 +882,11 @@ void brewdetection()
      bezugsZeit = millis() - timeBrewdetection ;
      }
     // Bezugstimmer für SW deaktivieren nach ende BD PID
-    if (millis() - timeBrewdetection > brewtimersoftware * 1000 && timerBrewdetection == 1 )
+    if (millis() - timeBrewdetection > brewtimersoftware * 1000 && timerBrewdetection == 1 && machinestate != 30)
     {
       timerBrewdetection = 0 ;    //rearm brewdetection
-      if (machinestate != 30)  // Bei Onlypid = 1, bezugsZeit > 0, no reset of bezugsZeit in case of brewing. 
-      {
-        bezugsZeit = 0 ;
+      bezugsZeit = 0 ;
       }
-     }
   } else if (Brewdetection == 2) 
   {
     if (millis() - timeBrewdetection > brewtimersoftware * 1000 && timerBrewdetection == 1 ) 


### PR DESCRIPTION
In der aktuellen Version bleibt im PID Only SW Brewdetection Modus der Brewtimer nach dem definierten Zeitraum einfach stehen (z.B. bei 30 sec). Es scheint als würde die innere if condition (mit der Prüfung des state) nicht mehr abgefragt werden. Der einfachste Fix war es die Prüfung mit in die äußere if condition aufzunehmen. Ein erster Test war erfolgreich.