### PR TITLE
overworked firmware version check

### DIFF
--- a/src/rancilio-pid.h
+++ b/src/rancilio-pid.h
@@ -1,0 +1,13 @@
+#ifndef _RANCILIO_PID_H_
+#define _RANCILIO_PID_H_
+
+#include <stdint.h>
+
+
+// Functions
+const char* getFwVersion(void);
+int readSysParamsFromStorage(void);
+int writeSysParamsToStorage(void);
+
+
+#endif

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -5,13 +5,17 @@
  *
  */
 
-#define SYSVERSION_USR '3.0.1 ALPHA'
-
 /**
  * Define area, do not change anything here
  */
 #ifndef _userConfig_H
 #define _userConfig_H
+
+// firmware version (must match with definitions in the main source file)
+#define USR_FW_VERSION    3
+#define USR_FW_SUBVERSION 0
+#define USR_FW_HOTFIX     1
+#define USR_FW_BRANCH     "ALPHA"
 
 // List of supported machines
 enum MACHINE {


### PR DESCRIPTION
- comparing strings at preprocessor level is not supported
- userConfig "match check" does not include the branch name (see 1st point)
- use separate defines for all firmware version parts to be more flexible
- added a general function to get the version as string (w/o any other stuff)
  this function can be used to build further strings containing the firmware version
- introduced rancilio-pid header file so that other modules may call some functions