### PR TITLE
Einheitliche Verwaltung von System-Parametern (SysParaClass)

### DIFF
--- a/src/RancilioServer.h
+++ b/src/RancilioServer.h
@@ -27,6 +27,7 @@
 
 enum EditableKind {
     kInteger,
+    kUInt8,
     kDouble,
     kDoubletime,
     kCString,
@@ -100,6 +101,10 @@ String generateForm(String varName) {
                 result += "<input class=\"form-control\" type=\"number\" step=\"1\"";
                 currVal = String(*(int *)e.ptr);
                 break;
+            case kUInt8:
+                result += "<input class=\"form-control\" type=\"number\" step=\"1\"";
+                currVal = String(*(uint8_t *)e.ptr);
+                break;
             default:
                 result += "<input class=\"form-control\" type=\"text\"";
                 currVal = (const char *)e.ptr;
@@ -135,6 +140,9 @@ String getValue(String varName) {
                 break;
             case kInteger:
                 return String(*(int *)e.ptr);
+                break;
+            case kUInt8:
+                return String(*(uint8_t *)e.ptr);
                 break;
             case kCString:
                 return String((const char *)e.ptr);
@@ -224,6 +232,10 @@ void serverSetup() {
                     *(int *)e.ptr = newVal;
                     m += ", it is now: ";
                     m += *(int *)e.ptr;
+                } else if (e.type == kUInt8) {
+                    *(uint8_t *)e.ptr = (uint8_t)atoi(p->value().c_str());
+                    m += ", it is now: ";
+                    m += *(uint8_t *)e.ptr;
                 } else if (e.type == kDouble ||e.type == kDoubletime) {
                     float newVal = atof(p->value().c_str());
                     *(double *)e.ptr = newVal;

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -647,8 +647,8 @@ int storageCommit(void) {
  *         <0 - failed
  */
 int storageFactoryReset(void) {
-        Serial.printf("%s(): reset all values\n", __FUNCTION__);
-        memset(EEPROM.getDataPtr(), 0xFF, sizeof(sto_data_t));
+    Serial.printf("%s(): reset all values\n", __FUNCTION__);
+    memset(EEPROM.getDataPtr(), 0xFF, sizeof(sto_data_t));
 
-        return storageCommit();
+    return storageCommit();
 }

--- a/src/SysPara.h
+++ b/src/SysPara.h
@@ -1,0 +1,120 @@
+/**
+ * @file SysParaClass.h
+ *
+ * @brief Class of system parameter
+ */
+
+#ifndef _SYS_PARA_CLASS_H_
+#define _SYS_PARA_CLASS_H_
+
+#include <Arduino.h>
+#include <stdint.h>
+#include "Storage.h"
+
+
+//! system parameter data
+template <typename T> struct sys_para_data
+{
+    T *curPtr;       //!< pointer to current value
+    T min;           //!< minimum value
+    T max;           //!< maximum value
+};
+
+//! system parameter class
+template <class T>
+class SysParaClass {
+    public:
+       /**
+        * @brief Constructor
+        *
+        * @param curPtr    - pointer to current value
+        * @param min       - minimum value
+        * @param max       - maximum value
+        * @param stoItemId - storage ID (optional, default=none)
+        *                    providing a storage ID will enable following features:
+        *                    - load initial value from storage at instantiation
+        *                    - provide functions to get/set from/to storage
+        */
+        SysParaClass(T* curPtr, T min, T max, sto_item_id_t stoItemId = STO_ITEM__LAST_ENUM) {
+            if (curPtr) {
+                _data.curPtr = curPtr;
+            } else {
+                Serial.printf("%s(): empty pointer!\n", __FUNCTION__);
+                _data.curPtr = (T*)&_dummyCur;
+            }
+            _data.min = min;
+            _data.max = max;
+            _stoItemId = stoItemId;
+            getStorage();           // init current value with storage value
+        }
+
+       /**
+        * @brief Returns the storage ID.
+        *
+        * @return storage ID (if exist) or STO_ITEM__LAST_ENUM
+        */
+        sto_item_id_t getStorageId(void) { return _stoItemId; }
+
+       /**
+        * @brief Returns the current value.
+        *
+        * @return current parameter value
+        */
+        T get(void) { return *_data.curPtr; }
+
+       /**
+        * @brief Returns the minimum value.
+        *
+        * @return minimum parameter value
+        */
+        T getMin(void) { return _data.min; }
+
+       /**
+        * @brief Returns the maximum value.
+        *
+        * @return maximum parameter value
+        */
+        T getMax(void) { return _data.max; }
+
+       /**
+        * @brief Reads the storage value into current value, if a valid storage ID
+        *        was given at instantiation.
+        *
+        * @return  0 - success, <0 - failure
+        */
+        int getStorage(void) {
+            int stoStatus;
+            if (_stoItemId < STO_ITEM__LAST_ENUM) {             // valid storage ID?
+                // use dummy variable to comply with storage API
+                if ((stoStatus = storageGet(_stoItemId, _dummyCur)) == 0)
+                    *_data.curPtr = _dummyCur;
+                return stoStatus;
+            }
+            Serial.printf("%s(): no storage ID set!\n", __FUNCTION__);
+            return -1;
+        }
+
+       /**
+        * @brief Writes the current value to storage, if a valid storage ID
+        *        was given at instantiation.
+        *
+        * @param commit - true=commit storage (optional, default=false)
+        *
+        * @return  0 - success, <0 - failure
+        */
+        int setStorage(bool commit = false) {
+            if (_stoItemId < STO_ITEM__LAST_ENUM)
+                return storageSet(_stoItemId, *_data.curPtr, commit);
+            Serial.printf("%s(): no storage ID set!\n", __FUNCTION__);
+            return -1;
+        }
+
+    private:
+        sto_item_id_t _stoItemId;       //!< storage item ID (if provided at instantiation)
+        sys_para_data<T> _data;         //!< parameter data
+        T _dummyCur;
+};
+
+
+
+#endif

--- a/src/SysPara.h
+++ b/src/SysPara.h
@@ -1,11 +1,11 @@
 /**
- * @file SysParaClass.h
+ * @file SysPara.h
  *
  * @brief Class of system parameter
  */
 
-#ifndef _SYS_PARA_CLASS_H_
-#define _SYS_PARA_CLASS_H_
+#ifndef _SYS_PARA_H_
+#define _SYS_PARA_H_
 
 #include <Arduino.h>
 #include <stdint.h>
@@ -22,7 +22,7 @@ template <typename T> struct sys_para_data
 
 //! system parameter class
 template <class T>
-class SysParaClass {
+class SysPara {
     public:
        /**
         * @brief Constructor
@@ -35,7 +35,7 @@ class SysParaClass {
         *                    - load initial value from storage at instantiation
         *                    - provide functions to get/set from/to storage
         */
-        SysParaClass(T* curPtr, T min, T max, sto_item_id_t stoItemId = STO_ITEM__LAST_ENUM) {
+        SysPara(T* curPtr, T min, T max, sto_item_id_t stoItemId = STO_ITEM__LAST_ENUM) {
             if (curPtr) {
                 _data.curPtr = curPtr;
             } else {

--- a/src/SysPara.h
+++ b/src/SysPara.h
@@ -103,8 +103,12 @@ class SysPara {
         * @return  0 - success, <0 - failure
         */
         int setStorage(bool commit = false) {
-            if (_stoItemId < STO_ITEM__LAST_ENUM)
-                return storageSet(_stoItemId, *_data.curPtr, commit);
+            if (_stoItemId < STO_ITEM__LAST_ENUM) {
+                if ((*_data.curPtr >= _data.min) && (*_data.curPtr <= _data.max))
+                    return storageSet(_stoItemId, *_data.curPtr, commit);
+                Serial.printf("%s(): value outside of range!\n", __FUNCTION__);
+                return -1;
+            }
             Serial.printf("%s(): no storage ID set!\n", __FUNCTION__);
             return -1;
         }

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -334,22 +334,22 @@ unsigned int MQTTReCnctCount = 0;  // Blynk Reconnection counter
 
 
 // system parameters (current value as pointer to variable, minimum, maximum, optional storage ID)
-SysParaClass<double> sysParaPidKpStart(&startKp, 0, 100, STO_ITEM_PID_KP_START);
-SysParaClass<double> sysParaPidTnStart(&startTn, 0, 999, STO_ITEM_PID_TN_START);
-SysParaClass<double> sysParaPidKpReg(&aggKp, 0, 100, STO_ITEM_PID_KP_REGULAR);
-SysParaClass<double> sysParaPidTnReg(&aggTn, 0, 999, STO_ITEM_PID_TN_REGULAR);
-SysParaClass<double> sysParaPidTvReg(&aggTv, 0, 999, STO_ITEM_PID_TV_REGULAR);
-SysParaClass<double> sysParaPidKpBd(&aggbKp, 0, 100, STO_ITEM_PID_KP_BD);
-SysParaClass<double> sysParaPidTnBd(&aggbTn, 0, 999, STO_ITEM_PID_TN_BD);
-SysParaClass<double> sysParaPidTvBd(&aggbTv, 0, 999, STO_ITEM_PID_TV_BD);
-SysParaClass<double> sysParaBrewSetPoint(&BrewSetPoint, 89, 105, STO_ITEM_BREW_SETPOINT);
-SysParaClass<double> sysParaBrewTime(&brewtime, 0, 60, STO_ITEM_BREW_TIME);
-SysParaClass<double> sysParaBrewSwTimer(&brewtimersoftware, 0, 999, STO_ITEM_BREW_SW_TIMER);
-SysParaClass<double> sysParaBrewThresh(&brewboarder, 0, 999, STO_ITEM_BD_THRESHOLD);
-SysParaClass<double> sysParaPreInfTime(&preinfusion, 0, 10, STO_ITEM_PRE_INFUSION_TIME);
-SysParaClass<double> sysParaPreInfPause(&preinfusionpause, 0, 20, STO_ITEM_PRE_INFUSION_PAUSE);
-SysParaClass<double> sysParaWeightSetPoint(&weightSetpoint, 0, 500, STO_ITEM_WEIGHTSETPOINT);
-SysParaClass<uint8_t> sysParaPidOn(&pidON, 0, 1, STO_ITEM_PID_ON);
+SysPara<double> sysParaPidKpStart(&startKp, 0, 100, STO_ITEM_PID_KP_START);
+SysPara<double> sysParaPidTnStart(&startTn, 0, 999, STO_ITEM_PID_TN_START);
+SysPara<double> sysParaPidKpReg(&aggKp, 0, 100, STO_ITEM_PID_KP_REGULAR);
+SysPara<double> sysParaPidTnReg(&aggTn, 0, 999, STO_ITEM_PID_TN_REGULAR);
+SysPara<double> sysParaPidTvReg(&aggTv, 0, 999, STO_ITEM_PID_TV_REGULAR);
+SysPara<double> sysParaPidKpBd(&aggbKp, 0, 100, STO_ITEM_PID_KP_BD);
+SysPara<double> sysParaPidTnBd(&aggbTn, 0, 999, STO_ITEM_PID_TN_BD);
+SysPara<double> sysParaPidTvBd(&aggbTv, 0, 999, STO_ITEM_PID_TV_BD);
+SysPara<double> sysParaBrewSetPoint(&BrewSetPoint, 89, 105, STO_ITEM_BREW_SETPOINT);
+SysPara<double> sysParaBrewTime(&brewtime, 0, 60, STO_ITEM_BREW_TIME);
+SysPara<double> sysParaBrewSwTimer(&brewtimersoftware, 0, 999, STO_ITEM_BREW_SW_TIMER);
+SysPara<double> sysParaBrewThresh(&brewboarder, 0, 999, STO_ITEM_BD_THRESHOLD);
+SysPara<double> sysParaPreInfTime(&preinfusion, 0, 10, STO_ITEM_PRE_INFUSION_TIME);
+SysPara<double> sysParaPreInfPause(&preinfusionpause, 0, 20, STO_ITEM_PRE_INFUSION_PAUSE);
+SysPara<double> sysParaWeightSetPoint(&weightSetpoint, 0, 500, STO_ITEM_WEIGHTSETPOINT);
+SysPara<uint8_t> sysParaPidOn(&pidON, 0, 1, STO_ITEM_PID_ON);
 
 
 enum MQTTSettableType {

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -334,15 +334,15 @@ unsigned int MQTTReCnctCount = 0;  // Blynk Reconnection counter
 
 
 // system parameters (current value as pointer to variable, minimum, maximum, optional storage ID)
-SysPara<double> sysParaPidKpStart(&startKp, 0, 100, STO_ITEM_PID_KP_START);
+SysPara<double> sysParaPidKpStart(&startKp, 0, 200, STO_ITEM_PID_KP_START);
 SysPara<double> sysParaPidTnStart(&startTn, 0, 999, STO_ITEM_PID_TN_START);
-SysPara<double> sysParaPidKpReg(&aggKp, 0, 100, STO_ITEM_PID_KP_REGULAR);
+SysPara<double> sysParaPidKpReg(&aggKp, 0, 200, STO_ITEM_PID_KP_REGULAR);
 SysPara<double> sysParaPidTnReg(&aggTn, 0, 999, STO_ITEM_PID_TN_REGULAR);
 SysPara<double> sysParaPidTvReg(&aggTv, 0, 999, STO_ITEM_PID_TV_REGULAR);
-SysPara<double> sysParaPidKpBd(&aggbKp, 0, 100, STO_ITEM_PID_KP_BD);
+SysPara<double> sysParaPidKpBd(&aggbKp, 0, 200, STO_ITEM_PID_KP_BD);
 SysPara<double> sysParaPidTnBd(&aggbTn, 0, 999, STO_ITEM_PID_TN_BD);
 SysPara<double> sysParaPidTvBd(&aggbTv, 0, 999, STO_ITEM_PID_TV_BD);
-SysPara<double> sysParaBrewSetPoint(&BrewSetPoint, 89, 105, STO_ITEM_BREW_SETPOINT);
+SysPara<double> sysParaBrewSetPoint(&BrewSetPoint, 85, 105, STO_ITEM_BREW_SETPOINT);
 SysPara<double> sysParaBrewTime(&brewtime, 0, 60, STO_ITEM_BREW_TIME);
 SysPara<double> sysParaBrewSwTimer(&brewtimersoftware, 0, 999, STO_ITEM_BREW_SW_TIMER);
 SysPara<double> sysParaBrewThresh(&brewboarder, 0, 999, STO_ITEM_BD_THRESHOLD);

--- a/src/rancilio-pid.h
+++ b/src/rancilio-pid.h
@@ -5,9 +5,9 @@
 
 
 // Functions
+int factoryReset(void);
 const char* getFwVersion(void);
 int readSysParamsFromStorage(void);
 int writeSysParamsToStorage(void);
-
 
 #endif


### PR DESCRIPTION
Die Klasse hat folgende Features:
- Verwaltung von Minimum/Maximum-Werten (zur Prüfung neuer Werte)
- optionales EEPROM-Handling (wenn beim Instanziieren eine Storage-ID angegeben wird): autom. Initialisieren mit EEPROM-Wert, Lesen/Schreiben)

Das kann natürlich dann noch weiter ausgebaut werden. Z. B. könnte man - ähnlich wie das EEPROM-Handling - auch das MQTT-Publish über die Klasse regeln, wenn beim Instanziieren ein MQTT-String angegeben wird.