### PR TITLE
SysPara enhancement

### DIFF
--- a/src/SysPara.h
+++ b/src/SysPara.h
@@ -112,12 +112,28 @@ class SysPara {
         }
 
        /**
+        * @brief Sets the current value.
+        *
+        * @param value - new current value
+        *
+        * @return 0 - success, <0 - failure
+        */
+        int set(T value) {
+            if ((value >= _data.min) && (value <= _data.max)) {
+                *_data.curPtr = value;
+                return 0;
+            }
+            Serial.printf("%s(): value outside of range!\n", __FUNCTION__);
+            return -1;
+        }
+
+       /**
         * @brief Writes the current value to storage, if a valid storage ID
         *        was given at instantiation.
         *
         * @param commit - true=commit storage (optional, default=false)
         *
-        * @return  0 - success, <0 - failure
+        * @return 0 - success, <0 - failure
         */
         int setStorage(bool commit = false) {
             if (_stoItemId < STO_ITEM__LAST_ENUM) {

--- a/src/SysPara.h
+++ b/src/SysPara.h
@@ -49,6 +49,22 @@ class SysPara {
         }
 
        /**
+        * @brief Constructor
+        *
+        * @param sysPara - system parameter object
+        */
+        explicit SysPara(T& sysPara) {
+            this = sysPara;
+        }
+
+       /**
+        * @brief Constructor used for extern declarations
+        */
+        explicit SysPara() {
+            _stoItemId = STO_ITEM__LAST_ENUM;
+        }
+
+       /**
         * @brief Returns the storage ID.
         *
         * @return storage ID (if exist) or STO_ITEM__LAST_ENUM

--- a/src/SysPara.h
+++ b/src/SysPara.h
@@ -84,10 +84,11 @@ class SysPara {
         */
         int getStorage(void) {
             int stoStatus;
-            if (_stoItemId < STO_ITEM__LAST_ENUM) {             // valid storage ID?
+            if (_stoItemId < STO_ITEM__LAST_ENUM) {                             // valid storage ID?
                 // use dummy variable to comply with storage API
                 if ((stoStatus = storageGet(_stoItemId, _dummyCur)) == 0)
-                    *_data.curPtr = _dummyCur;
+                    if ((_dummyCur >= _data.min) && (_dummyCur <= _data.max))   // valid value?
+                        *_data.curPtr = _dummyCur;                              // yes -> set current value
                 return stoStatus;
             }
             Serial.printf("%s(): no storage ID set!\n", __FUNCTION__);

--- a/src/rancilio-pid.h
+++ b/src/rancilio-pid.h
@@ -2,6 +2,27 @@
 #define _RANCILIO_PID_H_
 
 #include <stdint.h>
+#include "SysPara.h"
+
+
+// system parameters
+extern SysPara<double> sysParaPidKpStart;
+extern SysPara<double> sysParaPidTnStart;
+extern SysPara<double> sysParaPidKpReg;
+extern SysPara<double> sysParaPidTnReg;
+extern SysPara<double> sysParaPidTvReg;
+extern SysPara<double> sysParaPidKpBd;
+extern SysPara<double> sysParaPidTnBd;
+extern SysPara<double> sysParaPidTvBd;
+extern SysPara<double> sysParaBrewSetPoint;
+extern SysPara<double> sysParaBrewTime;
+extern SysPara<double> sysParaBrewSwTimer;
+extern SysPara<double> sysParaBrewThresh;
+extern SysPara<double> sysParaPreInfTime;
+extern SysPara<double> sysParaPreInfPause;
+extern SysPara<double> sysParaWeightSetPoint;
+extern SysPara<double> sysParaPidKpSteam;
+extern SysPara<uint8_t> sysParaPidOn;
 
 
 // Functions


### PR DESCRIPTION
Neben kleinen Verbesserungen, die aktuell noch nicht benutzt werden (und damit auch keine Probleme verursachen sollten), wird jetzt in der Funktion `getStorage()` der vom EEPROM gelesene Wert auf min/max geprüft, bevor er gesetzt wird. Dies ist wichtig für den Fall, wenn Benutzer die Version 3.0.x über eine vorhandene 2.9.4 installieren:
In 2.9.4 werden `preinfusion` und `preinfusionpause` als Millisekunden-Werte interpretiert (Default 2000/5000), aber in 3.0.x als Sekundenwerte (Default 2/5). Im EEPROM sind also Werte gespeichert, die ab 3.0.x falsch sind! Das würde zu ungewolltem Verhalten bzw. zu Fehlern beim Speichern führen (beim Speichern wird jetzt schon auf min/max. geprüft). Durch den ersten Commit dieses PRs wird nun auch der vom EEPROM gelesene Wert auf min/max geprüft. Schlägt die Prüfung fehl, wird der Wert nicht gesetzt und damit der initiale Defaultwert nicht mit einem ungültigem Wert überschrieben.
Als Ergebnis werden nach dem ersten Start von 3.0.x für die beiden Variablen die definierten Defaultwerte benutzt.