### PR TITLE
Fix: Display timer when brew is detected

### DIFF
--- a/src/Displaytemplatestandard.h
+++ b/src/Displaytemplatestandard.h
@@ -97,7 +97,7 @@ void printScreen()
             // Brew time or uptime
             u8g2.setCursor(32, 34);
 
-            if (brewDetected) {
+            if (isBrewDetected) {
                 //show shot time
                 u8g2.print(langstring_brew);
                 u8g2.print(timeBrewed / 1000, 0);


### PR DESCRIPTION
The uptime display broke the brewtimer in the default display.
It was introduced in 16d23dd82f2f025e9702ee01b70356b670b39a55
I only fixed the check for the brewdetection