### PR TITLE
Show uptime again after a brew with HW brew detection

### DIFF
--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -991,6 +991,7 @@ void brewDetection() {
 
         // OFF: reset brew
         if ((digitalRead(PINVOLTAGESENSOR) == VoltageSensorOFF) && (brewDetected == 1 || coolingFlushDetectedQM == true)) {
+            isBrewDetected = 0;  // rearm brewDetection
             brewDetected = 0;
             timePVStoON = timeBrewed;  // for QuickMill
             timeBrewed = 0;


### PR DESCRIPTION
This also resets the brew detected flag for the OnlyPID+ configuration (optocoupler for brew switch).
Otherwise Brew 0/25 will stay on the screen.