### PR TITLE
Show SW brew detection time parameter

### DIFF
--- a/data/html/index.htm
+++ b/data/html/index.htm
@@ -28,7 +28,7 @@
                         <div class="row row-cols-1 row-cols-md-3">
                             <div class="col-md-5 mb-4">
                                 <label class="form-label me-1 col-form-label">Current Temperature</label><br/>
-                                <b><span id="varTEMP">%VAR_SHOW_TEMP%</span> °C</b>
+                                <b><span id="varTEMP"></span> °C</b>
                             </div>
                                     
                             <template v-for="param in parameters">

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@ lib_deps =
     paulstoffregen/OneWire @ ^2.3.7
     adafruit/Adafruit_VL53L0X @ ^1.2.0
     olkal/HX711_ADC @ ^1.2.12
-    olikraus/U8g2 @ ^2.33.15
+    olikraus/U8g2 @ ^2.34.3
     git+https://github.com/kjyv/Arduino-PID-Library
     knolleary/PubSubClient @ ^2.8
     me-no-dev/AsyncTCP @ ^1.1.1

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -1896,7 +1896,7 @@ void setup() {
         {F("PID_BD_TV"), F("BD Tv (=Kd/Kp)"), true, F("Differential time constant (in seconds) for the PID when brewing has been detected."), kDouble, sBDSection, []{ return true && BREWDETECTION > 0 && useBDPID; }, PID_TV_BD_MIN, PID_TV_BD_MAX, (void *)&aggbTv},
 
         //#21
-        {F("PID_BD_TIMER"), F("PID BD Time (s)"), true, F("Fixed time in seconds for which the BD PID will stay enabled (also after Brew switch is inactive again)."), kDouble, sBDSection, []{ return true && BREWDETECTION > 0 && useBDPID; }, BREW_SW_TIMER_MIN, BREW_SW_TIMER_MAX, (void *)&brewtimersoftware},
+        {F("PID_BD_TIMER"), F("PID BD Time (s)"), true, F("Fixed time in seconds for which the BD PID will stay enabled (also after Brew switch is inactive again)."), kDouble, sBDSection, []{ return true && BREWDETECTION > 0 && (useBDPID || BREWDETECTION == 0); }, BREW_SW_TIMER_MIN, BREW_SW_TIMER_MAX, (void *)&brewtimersoftware},
 
         //#22
         {F("PID_BD_BREWSENSITIVITY"), F("PID BD Sensitivity"), true, F("Software brew detection sensitivity that looks at average temperature, <a href='https://manual.rancilio-pid.de/de/customization/brueherkennung.html' target='_blank'>Details</a>. Needs to be &gt;0 also for Hardware switch detection."), kDouble, sBDSection, []{ return true && BREWDETECTION == 1; }, BD_THRESHOLD_MIN, BD_THRESHOLD_MAX, (void *)&brewsensitivity},

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -1896,7 +1896,7 @@ void setup() {
         {F("PID_BD_TV"), F("BD Tv (=Kd/Kp)"), true, F("Differential time constant (in seconds) for the PID when brewing has been detected."), kDouble, sBDSection, []{ return true && BREWDETECTION > 0 && useBDPID; }, PID_TV_BD_MIN, PID_TV_BD_MAX, (void *)&aggbTv},
 
         //#21
-        {F("PID_BD_TIMER"), F("PID BD Time (s)"), true, F("Fixed time in seconds for which the BD PID will stay enabled (also after Brew switch is inactive again)."), kDouble, sBDSection, []{ return true && BREWDETECTION > 0 && (useBDPID || BREWDETECTION == 0); }, BREW_SW_TIMER_MIN, BREW_SW_TIMER_MAX, (void *)&brewtimersoftware},
+        {F("PID_BD_TIMER"), F("PID BD Time (s)"), true, F("Fixed time in seconds for which the BD PID will stay enabled (also after Brew switch is inactive again)."), kDouble, sBDSection, []{ return true && BREWDETECTION > 0 && (useBDPID || BREWDETECTION == 1); }, BREW_SW_TIMER_MIN, BREW_SW_TIMER_MAX, (void *)&brewtimersoftware},
 
         //#22
         {F("PID_BD_BREWSENSITIVITY"), F("PID BD Sensitivity"), true, F("Software brew detection sensitivity that looks at average temperature, <a href='https://manual.rancilio-pid.de/de/customization/brueherkennung.html' target='_blank'>Details</a>. Needs to be &gt;0 also for Hardware switch detection."), kDouble, sBDSection, []{ return true && BREWDETECTION == 1; }, BD_THRESHOLD_MIN, BD_THRESHOLD_MAX, (void *)&brewsensitivity},


### PR DESCRIPTION
When using software brew detection, allow settings max brew counter value without enabling bd pid.