### PR TITLE
Fix build for ESP32

### DIFF
--- a/src/ISR.h
+++ b/src/ISR.h
@@ -13,6 +13,10 @@ extern unsigned int isrCounter;
 extern unsigned int windowSize;
 extern bool skipHeaterISR;
 
+#if defined(ESP32)
+extern hw_timer_t *timer;
+#endif
+
 void initTimer1(void);
 void enableTimer1(void);
 void disableTimer1(void);


### PR DESCRIPTION
Compilation failed for ESP32, because "timer" reference to rancilio-pid.cpp had been undefined.