### PR TITLE
Display Menu (Buttons & Rotary Input)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ lib_deps =
     git+https://github.com/tzapu/WiFiManager @ 2.0.17
     git+https://github.com/madhephaestus/ESP32Encoder#9979722
     git+https://github.com/craftmetrics/esp32-button.git#36c6c0a
-    git+https://github.com/chris-dot-exe/MonoMenu#7f03578
+    git+https://github.com/chris-dot-exe/MonoMenu @ 0.1.2
 extra_scripts =
     pre:auto_firmware_version.py
     pre:run_clangformat.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,9 @@ lib_deps =
     git+https://github.com/esphome/AsyncTCP @ 2.1.3
     git+https://github.com/esphome/ESPAsyncWebServer#f2a65ff
     git+https://github.com/tzapu/WiFiManager @ 2.0.17
+    git+https://github.com/madhephaestus/ESP32Encoder#9979722
+    git+https://github.com/craftmetrics/esp32-button.git#36c6c0a
+    git+https://github.com/chris-dot-exe/MonoMenu#7f03578
 extra_scripts =
     pre:auto_firmware_version.py
     pre:run_clangformat.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,9 +24,9 @@ lib_deps =
     git+https://github.com/esphome/AsyncTCP @ 2.1.3
     git+https://github.com/esphome/ESPAsyncWebServer#f2a65ff
     git+https://github.com/tzapu/WiFiManager @ 2.0.17
-    git+https://github.com/madhephaestus/ESP32Encoder#9979722
     git+https://github.com/craftmetrics/esp32-button.git#36c6c0a
     git+https://github.com/chris-dot-exe/MonoMenu @ 0.1.2
+    madhephaestus/ESP32Encoder @ 0.11.5
 extra_scripts =
     pre:auto_firmware_version.py
     pre:run_clangformat.py

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -91,3 +91,5 @@ int writeSysParamsToStorage(void);
 #define PID_KP_STEAM_MAX       500
 #define STANDBY_MODE_TIME_MIN  30
 #define STANDBY_MODE_TIME_MAX  120
+
+#define ENCODER_CLICKS_PER_NOTCH 4

--- a/src/hardware/GPIOPin.cpp
+++ b/src/hardware/GPIOPin.cpp
@@ -55,3 +55,7 @@ void GPIOPin::setType(Type pinType) {
             break;
     }
 }
+
+int GPIOPin::getPinNumber() const {
+    return pin;
+}

--- a/src/hardware/GPIOPin.h
+++ b/src/hardware/GPIOPin.h
@@ -59,6 +59,12 @@ class GPIOPin {
          */
         Type getType() const;
 
+        /**
+         * @brief Returns pin number of this GPIO pin
+         * @return Pin number of this pin
+         */
+        int getPinNumber() const;
+
     private:
         /**
          * @brief Set the type of the GPIO pin

--- a/src/hardware/pinmapping.h
+++ b/src/hardware/pinmapping.h
@@ -17,10 +17,6 @@
 #define PIN_STEAMSWITCH 35
 #define PIN_WATERSWITCH 36
 
-#define PIN_ROTARY_DT  4 // Rotary encoder data pin
-#define PIN_ROTARY_CLK 3 // Rotary encoder clock pin
-#define PIN_ROTARY_SW  5 // Rotary encoder switch
-
 // Menu Input
 #define PIN_MENU_OUT_A 4 // Menu Input - Rotary encoder Output A / Data pin or down button
 #define PIN_MENU_OUT_B 3 // Menu Input - Rotary encoder Output B / CLK pin or up button

--- a/src/hardware/pinmapping.h
+++ b/src/hardware/pinmapping.h
@@ -21,6 +21,11 @@
 #define PIN_ROTARY_CLK 3 // Rotary encoder clock pin
 #define PIN_ROTARY_SW  5 // Rotary encoder switch
 
+// Menu Input
+#define PIN_MENU_OUT_A 4         // Menu Input - Rotary encoder Output A / Data pin or down button
+#define PIN_MENU_OUT_B 3         // Menu Input - Rotary encoder Output B / CLK pin or up button
+#define PIN_MENU_ENTER 5         // Menu Input - Rotary encoder switch or enter button
+
 // Sensors
 #define PIN_TEMPSENSOR  16
 #define PIN_WATERSENSOR 23

--- a/src/hardware/pinmapping.h
+++ b/src/hardware/pinmapping.h
@@ -22,9 +22,9 @@
 #define PIN_ROTARY_SW  5 // Rotary encoder switch
 
 // Menu Input
-#define PIN_MENU_OUT_A 4         // Menu Input - Rotary encoder Output A / Data pin or down button
-#define PIN_MENU_OUT_B 3         // Menu Input - Rotary encoder Output B / CLK pin or up button
-#define PIN_MENU_ENTER 5         // Menu Input - Rotary encoder switch or enter button
+#define PIN_MENU_OUT_A 4 // Menu Input - Rotary encoder Output A / Data pin or down button
+#define PIN_MENU_OUT_B 3 // Menu Input - Rotary encoder Output B / CLK pin or up button
+#define PIN_MENU_ENTER 5 // Menu Input - Rotary encoder switch or enter button
 
 // Sensors
 #define PIN_TEMPSENSOR  16

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1647,9 +1647,9 @@ void setup() {
     displayLogo(String("Version "), String(sysVersion));
     delay(2000); // caused crash with wifi manager on esp8266, should be ok on esp32
 
-    #if FEATURE_MENU == 1
-        initMenu(u8g2);
-    #endif
+#if FEATURE_MENU == 1
+    initMenu(u8g2);
+#endif
 #endif
 
     // Fallback offline

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1647,8 +1647,9 @@ void setup() {
     displayLogo(String("Version "), String(sysVersion));
     delay(2000); // caused crash with wifi manager on esp8266, should be ok on esp32
 
-    initMenu(u8g2);
-
+    #if FEATURE_MENU == 1
+        initMenu(u8g2);
+    #endif
 #endif
 
     // Fallback offline

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,6 +328,8 @@ Timer logbrew([&]() { LOGF(DEBUG, "(tB,T,hra) --> %5.2f %6.2f %8.2f", (double)(m
 // Embedded HTTP Server
 #include "embeddedWebserver.h"
 
+#include "menuHandler.h"
+
 enum SectionNames {
     sPIDSection,
     sTempSection,
@@ -1644,6 +1646,9 @@ void setup() {
     u8g2_prepare();
     displayLogo(String("Version "), String(sysVersion));
     delay(2000); // caused crash with wifi manager on esp8266, should be ok on esp32
+
+    initMenu(u8g2);
+
 #endif
 
     // Fallback offline
@@ -1859,6 +1864,27 @@ void looppid() {
     // Check if PID should run or not. If not, set to manual and force output to zero
 #if OLED_DISPLAY != 0
     printDisplayTimer();
+
+    if (menu != nullptr) {
+        menu->EventHandler();
+        menu->Loop();
+    }
+
+    if (menu == nullptr || !menu->IsOpen()) {
+        unsigned long currentMillisDisplay = millis();
+
+        if (currentMillisDisplay - previousMillisDisplay >= 100) {
+            displayShottimer();
+        }
+
+        if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
+            previousMillisDisplay = currentMillisDisplay;
+#if DISPLAYTEMPLATE < 20   // not using vertical template
+            displayMachineState();
+#endif
+            printScreen(); // refresh display
+        }
+    }
 #endif
 
     if (machineState == kPidDisabled || machineState == kWaterEmpty || machineState == kSensorError || machineState == kEmergencyStop || machineState == kEepromError || machineState == kStandby || brewPIDDisabled) {

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -154,7 +154,7 @@ void initMenu(U8G2& display) {
     pidSettings->AddInputItem("Tv", "Tv (=Kd/Kp)", "", "", PID_TV_REGULAR_MIN, PID_TV_REGULAR_MAX, []() { sysParaPidTvReg.setStorage(true); }, aggTv);
     pidSettings->AddInputItem("Integrator Max", "Integrator Max", "", "", PID_I_MAX_REGULAR_MIN, PID_I_MAX_REGULAR_MAX, []() { sysParaPidIMaxReg.setStorage(true); }, aggIMax);
     pidSettings->AddInputItem("Steam Kp", "Steam Kp", "", "", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, []() { sysParaPidKpSteam.setStorage(true); }, steamKp);
-    pidSettings->AddBackItem("Back", bitmap_icon_back);
+
 
     /* Brew PID Settings */
     Menu* brewPidSettings = new Menu(display);
@@ -167,6 +167,7 @@ void initMenu(U8G2& display) {
     brewPidSettings->AddBackItem("Back", bitmap_icon_back);
 
     pidSettings->AddSubMenu("Brew PID", *brewPidSettings);
+    pidSettings->AddBackItem("Back", bitmap_icon_back);
 
     advancedMenu->AddSubMenu("PID Settings", *pidSettings, bitmap_icon_pid);
     advancedMenu->AddBackItem("Back", bitmap_icon_back);

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -43,7 +43,7 @@ void saveStandbyTime() {
 }
 
 bool hasBrewControl() {
-    return BREWCONTROL_TYPE > 0;
+    return FEATURE_BREWCONTROL > 0;
 }
 
 bool hasScale() {

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -19,13 +19,38 @@ QueueHandle_t button_events;
 button_event_t ev;
 
 
-bool showMaintenance() {
+void saveBrewTemp() {
+    sysParaBrewSetpoint.setStorage(true);
+}
+
+void saveSteamTemp() {
+    sysParaSteamSetpoint.setStorage(true);
+}
+
+void savePIDOn() {
+    sysParaPidOn.setStorage(true);
+}
+
+void saveStandby() {
+    sysParaStandbyModeOn.setStorage(true);
+}
+
+void saveStandbyTime() {
+    sysParaStandbyModeTime.setStorage(true);
+}
+
+bool hasBrewControl() {
     return BREWCONTROL_TYPE > 0;
 }
 
-bool showBrewPIDSettings() {
-    return FEATURE_BREWDETECTION > 0;
+bool hasScale() {
+    return FEATURE_SCALE > 0;
 }
+
+bool hasSoftwareDetection() {
+    return BREWDETECTION_TYPE == 1;
+}
+
 
 
 void menuInputInit() {
@@ -48,18 +73,40 @@ void initMenu(U8G2& display) {
     menuInputInit();
 
     /* Main Menu */
-    menu->AddInputItem("Brew Temp.", "Brew Temperature", "", "°C", BREW_SETPOINT_MIN, BREW_SETPOINT_MAX, []() { sysParaPidOn.setStorage(); }, brewSetpoint, bitmap_icon_temp, 0.1, 0.5, true);
-    menu->AddInputItem("Steam Temp.", "Steam Temperature", "", "°C", STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, []() { sysParaSteamSetpoint.setStorage(); }, steamSetpoint, bitmap_icon_steam);
+    menu->AddInputItem("Brew Temp.", "Brew Temperature", "", "°C", BREW_SETPOINT_MIN, BREW_SETPOINT_MAX, saveBrewTemp, brewSetpoint, bitmap_icon_temp, 0.1, 0.5);
+    menu->AddInputItem("Steam Temp.", "Steam Temperature", "", "°C", STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, saveSteamTemp, steamSetpoint, bitmap_icon_steam,  0.1, 0.5);
 
-    menu->AddToggleItem("PID", []() { sysParaPidOn.setStorage(); }, reinterpret_cast<bool&>(pidON), bitmap_icon_pid);
+    menu->AddToggleItem("PID", savePIDOn, reinterpret_cast<bool&>(pidON), bitmap_icon_pid);
 
     menu->SetEventHandler([&]() {
                 if (xQueueReceive(button_events, &ev, 1 / portTICK_PERIOD_MS)) {
+
                     if (ev.pin == menuEnterPin->getPinNumber()) {
+                        if (standbyModeRemainingTimeMillis == 0) {
+                                resetStandbyTimer();
+                                display.setPowerSave(0);
+                                pidON = 1;
+                                if (steamON) {
+                                    machineState = kSteam;
+                                }
+                                else if (isBrewDetected) {
+                                    machineState = kBrew;
+                                }
+                                else {
+                                    machineState = kPidOffline;
+                                }
+                            return;
+                        }
+                        if (ev.event == EventState::STATE_DOWN) {
+                            resetStandbyTimer();
+                        }
                         menu->Event(EVENT_ENTER, EventState(ev.event));
+
                     } else if (ev.pin == menuUpPin->getPinNumber()) {
+                        resetStandbyTimer();
                         menu->Event(EVENT_UP, EventState(ev.event));
                     } else if (ev.pin == menuDownPin->getPinNumber()) {
+                        resetStandbyTimer();
                         menu->Event(EVENT_DOWN, EventState(ev.event));
                     }
                 }
@@ -67,17 +114,17 @@ void initMenu(U8G2& display) {
 
     /* Brew Weight & Time */
     Menu* weightNTime = new Menu(display);
-    weightNTime->AddInputItem("Brew by Time", "Brew Time", "", " s", BREW_TIME_MIN, BREW_TIME_MAX, []() { sysParaBrewTime.setStorage(); }, brewTime, bitmap_icon_clock);
-    weightNTime->AddInputItem("Brew by Weight", "Brew Weight", "", "g", WEIGHTSETPOINT_MIN, WEIGHTSETPOINT_MAX, []() { sysParaWeightSetpoint.setStorage(); }, weightSetpoint, bitmap_icon_scale);
+    weightNTime->AddInputItem("Brew by Time", "Brew Time", "", " s", BREW_TIME_MIN, BREW_TIME_MAX, []() { sysParaBrewTime.setStorage(true); }, brewTime, bitmap_icon_clock);
+    weightNTime->AddInputItem("Brew by Weight", "Brew Weight", "", "g", WEIGHTSETPOINT_MIN, WEIGHTSETPOINT_MAX, []() { sysParaWeightSetpoint.setStorage(true); }, weightSetpoint, bitmap_icon_scale, hasScale());
     weightNTime->AddBackItem("Back", bitmap_icon_back);
-    menu->AddSubMenu("Brew Time & Weight", *weightNTime, false);
+    menu->AddSubMenu("Brew Time & Weight", *weightNTime, hasBrewControl());
 
     /* Preinfusion */
     Menu* preInfusion = new Menu(display);
-    preInfusion->AddInputItem("Preinfusion Pause", "Pause", "", "s", PRE_INFUSION_PAUSE_MIN, PRE_INFUSION_PAUSE_MAX, []() { sysParaPreInfPause.setStorage(); }, preinfusionPause, 1.0, 2.0, true);
-    preInfusion->AddInputItem("Preinfusion", "Time", "", "s", PRE_INFUSION_TIME_MIN, PRE_INFUSION_TIME_MAX, []() { sysParaPreInfTime.setStorage(); }, preinfusion, 1.0, 2.0, true);
+    preInfusion->AddInputItem("Preinfusion Pause", "Pause", "", "s", PRE_INFUSION_PAUSE_MIN, PRE_INFUSION_PAUSE_MAX, []() { sysParaPreInfPause.setStorage(true); }, preinfusionPause, 1.0, 2.0, true);
+    preInfusion->AddInputItem("Preinfusion", "Time", "", "s", PRE_INFUSION_TIME_MIN, PRE_INFUSION_TIME_MAX, []() { sysParaPreInfTime.setStorage(true); }, preinfusion, 1.0, 2.0, true);
     preInfusion->AddBackItem("Back", bitmap_icon_back);
-    menu->AddSubMenu("Preinfusion", *preInfusion, false);
+    menu->AddSubMenu("Preinfusion", *preInfusion, hasBrewControl());
     /*
      * Maintenance Menu
      * */
@@ -85,38 +132,47 @@ void initMenu(U8G2& display) {
     maintenanceMenu->AddToggleItem("Backflush", reinterpret_cast<bool&>(backflushOn), bitmap_icon_refresh);
     maintenanceMenu->AddBackItem("Back", bitmap_icon_back);
 
-    menu->AddSubMenu("Maintenance", *maintenanceMenu, bitmap_icon_tools, showMaintenance());
+    menu->AddSubMenu("Maintenance", *maintenanceMenu, bitmap_icon_tools, hasBrewControl());
 
     /*
      * Advanced Menu
      */
 
     Menu* advancedMenu = new Menu(display);
-    advancedMenu->AddInputItem("Brew Temp. Offset", "Brew temp. offset", "", "°C", BREW_TEMP_OFFSET_MIN, BREW_TEMP_OFFSET_MAX, []() { sysParaTempOffset.setStorage(); }, brewTempOffset, bitmap_icon_temp);
+    advancedMenu->AddInputItem("Brew Temp. Offset", "Brew temp. offset", "", "°C", BREW_TEMP_OFFSET_MIN, BREW_TEMP_OFFSET_MAX, []() { sysParaTempOffset.setStorage(true); }, brewTempOffset, bitmap_icon_temp);
     /*
      * Standby Menu
      */
     Menu* standbyMenu = new Menu(display);
-    standbyMenu->AddToggleItem("Standby", []() { sysParaStandbyModeOn.setStorage(); }, reinterpret_cast<bool&>(standbyModeOn), true);
-    standbyMenu->AddInputItem("Standby Time", "Standby Time", "", " m", STANDBY_MODE_TIME_MIN, STANDBY_MODE_TIME_MAX, []() { sysParaStandbyModeTime.setStorage(); }, standbyModeTime, bitmap_icon_clock, 1.0, 2.0, true);
+    standbyMenu->AddToggleItem("Standby", saveStandby, reinterpret_cast<bool&>(standbyModeOn), true);
+    standbyMenu->AddInputItem("Standby Time", "Standby Time", "", " m", STANDBY_MODE_TIME_MIN, STANDBY_MODE_TIME_MAX, saveStandbyTime, standbyModeTime, bitmap_icon_clock, 1.0, 2.0, true);
 
     standbyMenu->AddBackItem("Back", bitmap_icon_back);
     advancedMenu->AddSubMenu("Standby", *standbyMenu, bitmap_icon_sleep_mode);
 
     /* PID Settings */
     Menu* pidSettings = new Menu(display);
-    pidSettings->AddToggleItem("Enable PonM", []() { sysParaUsePonM.setStorage(); }, reinterpret_cast<bool&>(usePonM));
-    pidSettings->AddInputItem("Start Kp", "Start Kp", "", "", PID_KP_START_MIN, PID_KP_START_MAX, []() { (sysParaPidKpStart.setStorage()); }, startKp);
-    pidSettings->AddInputItem("Start Tn", "Start Tn", "", "", PID_TN_START_MIN, PID_TN_START_MAX, []() { sysParaPidTnStart.setStorage(); }, startTn);
-    pidSettings->AddInputItem("Kp", "Kp", "", "", PID_KP_REGULAR_MIN, PID_KP_REGULAR_MAX, []() { sysParaPidKpReg.setStorage(); }, aggKp);
-    pidSettings->AddInputItem("Tn", "Tn (=Kp/Ki)", "", "", PID_TN_REGULAR_MIN, PID_TN_REGULAR_MAX, []() { sysParaPidTnReg.setStorage(); }, aggTn);
-    pidSettings->AddInputItem("Tv", "Tv (=Kd/Kp)", "", "", PID_TV_REGULAR_MIN, PID_TV_REGULAR_MAX, []() { sysParaPidTvReg.setStorage(); }, aggTv);
-    pidSettings->AddInputItem("Integrator Max", "Integrator Max", "", "", PID_I_MAX_REGULAR_MIN, PID_I_MAX_REGULAR_MAX, []() { sysParaPidIMaxReg.setStorage(); }, aggIMax);
-    pidSettings->AddInputItem("Steam Kp", "Steam Kp", "", "", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, []() { sysParaPidKpSteam.setStorage(); }, steamKp);
+    pidSettings->AddToggleItem("Enable PonM", []() { sysParaUsePonM.setStorage(true); }, reinterpret_cast<bool&>(usePonM));
+    pidSettings->AddInputItem("Start Kp", "Start Kp", "", "", PID_KP_START_MIN, PID_KP_START_MAX, []() { (sysParaPidKpStart.setStorage(true)); }, startKp);
+    pidSettings->AddInputItem("Start Tn", "Start Tn", "", "", PID_TN_START_MIN, PID_TN_START_MAX, []() { sysParaPidTnStart.setStorage(true); }, startTn);
+    pidSettings->AddInputItem("Kp", "Kp", "", "", PID_KP_REGULAR_MIN, PID_KP_REGULAR_MAX, []() { sysParaPidKpReg.setStorage(true); }, aggKp);
+    pidSettings->AddInputItem("Tn", "Tn (=Kp/Ki)", "", "", PID_TN_REGULAR_MIN, PID_TN_REGULAR_MAX, []() { sysParaPidTnReg.setStorage(true); }, aggTn);
+    pidSettings->AddInputItem("Tv", "Tv (=Kd/Kp)", "", "", PID_TV_REGULAR_MIN, PID_TV_REGULAR_MAX, []() { sysParaPidTvReg.setStorage(true); }, aggTv);
+    pidSettings->AddInputItem("Integrator Max", "Integrator Max", "", "", PID_I_MAX_REGULAR_MIN, PID_I_MAX_REGULAR_MAX, []() { sysParaPidIMaxReg.setStorage(true); }, aggIMax);
+    pidSettings->AddInputItem("Steam Kp", "Steam Kp", "", "", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, []() { sysParaPidKpSteam.setStorage(true); }, steamKp);
     pidSettings->AddBackItem("Back", bitmap_icon_back);
 
     /* Brew PID Settings */
+    Menu * brewPidSettings = new Menu(display);
+    brewPidSettings->AddToggleItem("Enable Brew PID", []() { sysParaUsePonM.setStorage(true); }, reinterpret_cast<bool&>(useBDPID));
+    brewPidSettings->AddInputItem("BD Kp", "BD Kp", "", "", PID_KP_BD_MIN, PID_KP_BD_MAX, []() { sysParaPidKpBd.setStorage(true); }, aggbKp);
+    brewPidSettings->AddInputItem("BD Tn", "BD Tn (=Kp/Ki)", "", "", PID_TN_BD_MIN, PID_TN_BD_MAX, []() { sysParaPidTnBd.setStorage(true); }, aggbTn);
+    brewPidSettings->AddInputItem("BD Tv", "BD Tv (=Kd/Kp)", "", "", PID_TV_BD_MIN, PID_TV_BD_MAX, []() { sysParaPidTvBd.setStorage(true); }, aggbTv);
+    brewPidSettings->AddInputItem("PID BD Time", "PID BD Time", "", "s", BREW_SW_TIME_MIN, BREW_SW_TIME_MAX, []() { sysParaBrewSwTime.setStorage(true); }, brewtimesoftware, hasSoftwareDetection());
+    brewPidSettings->AddInputItem("PID BD Sensitivity", "Sensitivity", "", "", BD_THRESHOLD_MIN, BD_THRESHOLD_MAX, []() { sysParaBrewThresh.setStorage(true); }, brewSensitivity, hasSoftwareDetection());
+    brewPidSettings->AddBackItem("Back", bitmap_icon_back);
 
+    pidSettings->AddSubMenu("Brew PID", *brewPidSettings);
 
     advancedMenu->AddSubMenu("PID Settings", *pidSettings, bitmap_icon_pid);
     advancedMenu->AddBackItem("Back", bitmap_icon_back);

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -1,0 +1,131 @@
+
+#pragma once
+
+#include <Menu.h>
+#include <hardware/pinmapping.h>
+#include <icons/menuIcons.h>
+#include <button.h>
+
+enum MENUINPUT {
+    BUTTONS,
+    ROTARY,
+};
+
+Menu* menu;
+GPIOPin* menuEnterPin;
+GPIOPin* menuUpPin;
+GPIOPin* menuDownPin;
+QueueHandle_t button_events;
+button_event_t ev;
+
+
+bool showMaintenance() {
+    return BREWCONTROL_TYPE > 0;
+}
+
+bool showBrewPIDSettings() {
+    return FEATURE_BREWDETECTION > 0;
+}
+
+
+void menuInputInit() {
+    if (MENU_INPUT == MENUINPUT::BUTTONS) {
+        menuEnterPin = new GPIOPin(PIN_MENU_ENTER, GPIOPin::IN_PULLUP);
+        menuUpPin = new GPIOPin(PIN_MENU_OUT_A, GPIOPin::IN_PULLUP);
+        menuDownPin = new GPIOPin(PIN_MENU_OUT_B, GPIOPin::IN_PULLUP);
+
+        button_events = pulled_button_init(
+            PIN_BIT(menuEnterPin->getPinNumber()) |
+                PIN_BIT(menuUpPin->getPinNumber()) |
+                PIN_BIT(menuDownPin->getPinNumber()), GPIO_PULLUP_ONLY
+        );
+    }
+}
+
+void initMenu(U8G2& display) {
+    menu = new Menu(display);
+
+    menuInputInit();
+
+    /* Main Menu */
+    menu->AddInputItem("Brew Temp.", "Brew Temperature", "", "°C", BREW_SETPOINT_MIN, BREW_SETPOINT_MAX, []() { sysParaPidOn.setStorage(); }, brewSetpoint, bitmap_icon_temp, 0.1, 0.5, true);
+    menu->AddInputItem("Steam Temp.", "Steam Temperature", "", "°C", STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, []() { sysParaSteamSetpoint.setStorage(); }, steamSetpoint, bitmap_icon_steam);
+
+    menu->AddToggleItem("PID", []() { sysParaPidOn.setStorage(); }, reinterpret_cast<bool&>(pidON), bitmap_icon_pid);
+
+    menu->SetEventHandler([&]() {
+                if (xQueueReceive(button_events, &ev, 1 / portTICK_PERIOD_MS)) {
+                    if (ev.pin == menuEnterPin->getPinNumber()) {
+                        menu->Event(EVENT_ENTER, EventState(ev.event));
+                    } else if (ev.pin == menuUpPin->getPinNumber()) {
+                        menu->Event(EVENT_UP, EventState(ev.event));
+                    } else if (ev.pin == menuDownPin->getPinNumber()) {
+                        menu->Event(EVENT_DOWN, EventState(ev.event));
+                    }
+                }
+    });
+
+    /* Brew Weight & Time */
+    Menu* weightNTime = new Menu(display);
+    weightNTime->AddInputItem("Brew by Time", "Brew Time", "", " s", BREW_TIME_MIN, BREW_TIME_MAX, []() { sysParaBrewTime.setStorage(); }, brewTime, bitmap_icon_clock);
+    weightNTime->AddInputItem("Brew by Weight", "Brew Weight", "", "g", WEIGHTSETPOINT_MIN, WEIGHTSETPOINT_MAX, []() { sysParaWeightSetpoint.setStorage(); }, weightSetpoint, bitmap_icon_scale);
+    weightNTime->AddBackItem("Back", bitmap_icon_back);
+    menu->AddSubMenu("Brew Time & Weight", *weightNTime, false);
+
+    /* Preinfusion */
+    Menu* preInfusion = new Menu(display);
+    preInfusion->AddInputItem("Preinfusion Pause", "Pause", "", "s", PRE_INFUSION_PAUSE_MIN, PRE_INFUSION_PAUSE_MAX, []() { sysParaPreInfPause.setStorage(); }, preinfusionPause, 1.0, 2.0, true);
+    preInfusion->AddInputItem("Preinfusion", "Time", "", "s", PRE_INFUSION_TIME_MIN, PRE_INFUSION_TIME_MAX, []() { sysParaPreInfTime.setStorage(); }, preinfusion, 1.0, 2.0, true);
+    preInfusion->AddBackItem("Back", bitmap_icon_back);
+    menu->AddSubMenu("Preinfusion", *preInfusion, false);
+    /*
+     * Maintenance Menu
+     * */
+    Menu* maintenanceMenu = new Menu(display);
+    maintenanceMenu->AddToggleItem("Backflush", reinterpret_cast<bool&>(backflushOn), bitmap_icon_refresh);
+    maintenanceMenu->AddBackItem("Back", bitmap_icon_back);
+
+    menu->AddSubMenu("Maintenance", *maintenanceMenu, bitmap_icon_tools, showMaintenance());
+
+    /*
+     * Advanced Menu
+     */
+
+    Menu* advancedMenu = new Menu(display);
+    advancedMenu->AddInputItem("Brew Temp. Offset", "Brew temp. offset", "", "°C", BREW_TEMP_OFFSET_MIN, BREW_TEMP_OFFSET_MAX, []() { sysParaTempOffset.setStorage(); }, brewTempOffset, bitmap_icon_temp);
+    /*
+     * Standby Menu
+     */
+    Menu* standbyMenu = new Menu(display);
+    standbyMenu->AddToggleItem("Standby", []() { sysParaStandbyModeOn.setStorage(); }, reinterpret_cast<bool&>(standbyModeOn), true);
+    standbyMenu->AddInputItem("Standby Time", "Standby Time", "", " m", STANDBY_MODE_TIME_MIN, STANDBY_MODE_TIME_MAX, []() { sysParaStandbyModeTime.setStorage(); }, standbyModeTime, bitmap_icon_clock, 1.0, 2.0, true);
+
+    standbyMenu->AddBackItem("Back", bitmap_icon_back);
+    advancedMenu->AddSubMenu("Standby", *standbyMenu, bitmap_icon_sleep_mode);
+
+    /* PID Settings */
+    Menu* pidSettings = new Menu(display);
+    pidSettings->AddToggleItem("Enable PonM", []() { sysParaUsePonM.setStorage(); }, reinterpret_cast<bool&>(usePonM));
+    pidSettings->AddInputItem("Start Kp", "Start Kp", "", "", PID_KP_START_MIN, PID_KP_START_MAX, []() { (sysParaPidKpStart.setStorage()); }, startKp);
+    pidSettings->AddInputItem("Start Tn", "Start Tn", "", "", PID_TN_START_MIN, PID_TN_START_MAX, []() { sysParaPidTnStart.setStorage(); }, startTn);
+    pidSettings->AddInputItem("Kp", "Kp", "", "", PID_KP_REGULAR_MIN, PID_KP_REGULAR_MAX, []() { sysParaPidKpReg.setStorage(); }, aggKp);
+    pidSettings->AddInputItem("Tn", "Tn (=Kp/Ki)", "", "", PID_TN_REGULAR_MIN, PID_TN_REGULAR_MAX, []() { sysParaPidTnReg.setStorage(); }, aggTn);
+    pidSettings->AddInputItem("Tv", "Tv (=Kd/Kp)", "", "", PID_TV_REGULAR_MIN, PID_TV_REGULAR_MAX, []() { sysParaPidTvReg.setStorage(); }, aggTv);
+    pidSettings->AddInputItem("Integrator Max", "Integrator Max", "", "", PID_I_MAX_REGULAR_MIN, PID_I_MAX_REGULAR_MAX, []() { sysParaPidIMaxReg.setStorage(); }, aggIMax);
+    pidSettings->AddInputItem("Steam Kp", "Steam Kp", "", "", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, []() { sysParaPidKpSteam.setStorage(); }, steamKp);
+    pidSettings->AddBackItem("Back", bitmap_icon_back);
+
+    /* Brew PID Settings */
+
+
+    advancedMenu->AddSubMenu("PID Settings", *pidSettings, bitmap_icon_pid);
+    advancedMenu->AddBackItem("Back", bitmap_icon_back);
+    menu->AddSubMenu("Advanced", *advancedMenu, bitmap_icon_settings);
+
+    menu->AddBackItem("Close Menu", bitmap_icon_back);
+    menu->Init();
+}
+
+void menuLoop() {
+    menu->Loop();
+}

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -64,7 +64,6 @@ void menuInputInit() {
             button_events = pulled_button_init(PIN_BIT(menuEnterPin->getPinNumber()) | PIN_BIT(menuUpPin->getPinNumber()) | PIN_BIT(menuDownPin->getPinNumber()), GPIO_PULLUP_ONLY);
             break;
         case MENUINPUT::ROTARY:
-            // TODO add rotary setup
             menuEnterPin = new GPIOPin(PIN_MENU_ENTER, GPIOPin::IN_PULLUP);
             menuUpPin = new GPIOPin(PIN_MENU_OUT_A, GPIOPin::IN_PULLUP);
             menuDownPin = new GPIOPin(PIN_MENU_OUT_B, GPIOPin::IN_PULLUP);
@@ -130,12 +129,12 @@ void initMenu(U8G2& display) {
         }
         if (MENU_INPUT == MENUINPUT::ROTARY) {
             int32_t pos = encoder.getCount() / ENCODER_CLICKS_PER_NOTCH;
-            if (pos < last) {
+            if (pos > last) {
                 menu->Event(EVENT_UP, EventState(EventState::STATE_DOWN));
                 LOG(DEBUG, "Menu: Up\n");
                 menu->Event(EVENT_UP, EventState(EventState::STATE_UP));
             }
-            else if (pos > last) {
+            else if (pos < last) {
                 menu->Event(EVENT_DOWN, EventState(EventState::STATE_DOWN));
                 LOG(DEBUG, "Menu: Down\n");
                 menu->Event(EVENT_DOWN, EventState(EventState::STATE_UP));

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -20,8 +20,6 @@ ESP32Encoder encoder;
 QueueHandle_t button_events;
 button_event_t ev;
 
-double menuRotaryLast = 0;
-double initialValue = 0;
 int last = 0;
 
 void saveBrewTemp() {

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -155,7 +155,6 @@ void initMenu(U8G2& display) {
     pidSettings->AddInputItem("Integrator Max", "Integrator Max", "", "", PID_I_MAX_REGULAR_MIN, PID_I_MAX_REGULAR_MAX, []() { sysParaPidIMaxReg.setStorage(true); }, aggIMax);
     pidSettings->AddInputItem("Steam Kp", "Steam Kp", "", "", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, []() { sysParaPidKpSteam.setStorage(true); }, steamKp);
 
-
     /* Brew PID Settings */
     Menu* brewPidSettings = new Menu(display);
     brewPidSettings->AddToggleItem("Enable Brew PID", []() { sysParaUsePonM.setStorage(true); }, reinterpret_cast<bool&>(useBDPID));

--- a/src/menuHandler.h
+++ b/src/menuHandler.h
@@ -93,7 +93,7 @@ void initMenu(U8G2& display) {
                                     machineState = kBrew;
                                 }
                                 else {
-                                    machineState = kPidOffline;
+                                    machineState = kPidDisabled;
                                 }
                             return;
                         }

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -40,7 +40,11 @@ enum MACHINE {
 #define FEATURE_PIDOFF_LOGO   1       // 0 = deactivated, 1 = activated
 #define SHOTTIMERDISPLAYDELAY 3000    // time in ms that shot timer will be shown after brew finished
 
-#define LANGUAGE 0                    // LANGUAGE = 0 (DE), LANGUAGE = 1 (EN), LANGUAGE = 2 (ES)
+// Display Menu
+#define FEATURE_MENU 0                  // 0 = deactivated, 1 = enabled
+#define MENU_INPUT   MENUINPUT::BUTTONS // MENUINPUT::BUTTONS = input with three buttons, MENUINPUT::ROTARY = input with rotary encoder with shaft switch
+
+#define LANGUAGE 0                      // LANGUAGE = 0 (DE), LANGUAGE = 1 (EN), LANGUAGE = 2 (ES)
 
 // Connectivity
 #define CONNECTMODE         1              // 0 = offline 1 = WIFI-MODE


### PR DESCRIPTION
I started to make the menu from @FabianSperrle working again and since I wasn't really happy with the used menu library I got carried away and worked on a new one. (It's currently only used with clevercoffee - will make it more flexible in the future)

The menu is capable to set (most) parameters without using the website. 

If used with buttons as input the buttons use the same pins as 'reserved' for the rotary encoder, so the menu is controlled with three buttons (up, down, enter)

Depending on the activated features, more or less options are visible. 
For example, Brew Time & Weight, Preinfusion and the Maintenance Item (currently only contains Backflush) are only visible if `BREWCONTROL_TYPE > 0` etc. 

The menu uses https://github.com/craftmetrics/esp32-button for button press detection and debouncing. 

### Activate
To enable the Menu, set `FEATURE_MENU` to `1` in the userConfig.h
`MENU_INPUT` supports `MENUINPUT::BUTTONS` and `MENUINPUT::ROTARY`

### Menu Structure
Available Menu Items are at the moment:
- Brew Temp.
- Steam Temp.
- PID (Toggle on/off)
- Brew Time & Weight
  - Brew by Time
  - Brew by Weight
- Preinfusion
  - Preinfusion Pause
  - Preinfusion (Time)
- Maintenance
  - Backflush (Toggle on/off)
- Advanced
  - Brew Temp. Offset
  - Standby
    - Standby (Toggle on/off)
    - Standby Time
  - PID Settings
    - Enable PonM (Toggle on/off)
    - Start Kp
    - Start Tn
    - Kp
    - Tn
    - Tv
    - Integrator Max
    - Steam Kp
    - Brew PID
      - Enable Brew PID (Toggle on/off)
      - BD Kp
      - BD Tn
      - BD Tv
      - PID BD Time
      - PID BD Sensitivity

      
### Menu Control
- The last item is always `Back` or `Close Menu`
- Toggle Items have a 'radio button' icon at the end which is toggled like a radio button ;) 
- Input Items have a setable Value which is displayed as a float or integer and can be increased/decreased with the up/down buttons, saved (to the eeprom) with a short click on the enter button or aborted with a long hold of the enter button. 
  - (Long Hold) of up/down increase the speed 
  - Values are only setable within the limits which are already defined for the website. 
- every enter event in the menu also resets the standby timer
- if the machine is in standby, the enter button can wake it up

Since I don't have a 'full expansion' yet, I couldn't test everything...
So, let me know what you guys think... (I'm also in the Discord under the name Kuraiko) 

PS: It most certainly won't work with the vertical display 

![PXL_20240418_214340018 MP~2](https://github.com/rancilio-pid/clevercoffee/assets/49272981/8124f36a-17fc-4076-b140-bb7928b777f8)
![PXL_20240418_214410127 MP~2](https://github.com/rancilio-pid/clevercoffee/assets/49272981/467753c2-e7c3-4ec0-a445-46e4d51ec9ba)
![PXL_20240418_214428274 MP~2](https://github.com/rancilio-pid/clevercoffee/assets/49272981/edabcc33-d9ae-48f8-821e-aea05d421911)

