### PR TITLE
Refactor brew detection and brew handling

### DIFF
--- a/data/js/app.js
+++ b/data/js/app.js
@@ -74,11 +74,13 @@ const vueApp = Vue.createApp({
         sectionName(sectionId) {
             const sectionNames = {
                 0: 'PID Parameters',
-                1: 'Temperature and Preinfusion',
-                2: 'Brew Detection and Brew PID Parameters',
+                1: 'Temperature',
+                2: 'Brew PID Parameters',
                 3: 'Brew Control',
                 4: 'Scale Parameters',
-                5: 'Power Settings'
+                5: 'Display Settings',
+                6: 'Maintenance',
+                7: 'Power Settings'
             }
 
             return sectionNames[sectionId]

--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -4,54 +4,68 @@
  * @brief Handler for brewing
  *
  */
+// TODO:
+//  show sections on website only if needed
+//  add pressure to shot timer?
+//  backflush also as bool, enable from website over diffrent var
+//  SteamOn also as bool, rethink enable from website
 
 #pragma once
 
-#include <hardware/pinmapping.h>
-
 enum BrewSwitchState {
     kBrewSwitchIdle = 10,
-    kBrewSwitchBrew = 20,
-    kBrewSwitchBrewAbort = 30,
-    kBrewSwitchFlushOff = 31,
-    kBrewSwitchReset = 40
+    kBrewSwitchPressed = 20,
+    kBrewSwitchShortPressed = 30,
+    kBrewSwitchLongPressed = 40,
+    kBrewSwitchWaitForRelease = 50
 };
 
 enum BrewState {
     kBrewIdle = 10,
     kPreinfusion = 20,
-    kWaitPreinfusion = 21,
     kPreinfusionPause = 30,
-    kWaitPreinfusionPause = 31,
     kBrewRunning = 40,
-    kWaitBrew = 41,
-    kBrewFinished = 42,
-    kWaitBrewOff = 43
+    kBrewFinished = 50,
+};
+
+enum ManualFlushState {
+    kManualFlushIdle = 10,
+    kManualFlushRunning = 20,
 };
 
 enum BackflushState {
-    kBackflushWaitBrewswitchOn = 10,
-    kBackflushFillingStart = 20,
-    kBackflushFilling = 21,
-    kBackflushFlushingStart = 30,
-    kBackflushFlushing = 31,
-    kBackflushWaitBrewswitchOff = 43
+    kBackflushIdle = 10,
+    kBackflushFilling = 20,
+    kBackflushFlushing = 30,
+    kBackflushFinished = 40
 };
 
-// Normal Brew
+// Brew control states
+BrewSwitchState currBrewSwitchState = kBrewSwitchIdle;
 BrewState currBrewState = kBrewIdle;
+ManualFlushState currManualFlushState = kManualFlushIdle;
+BackflushState currBackflushState = kBackflushIdle;
 
-uint8_t currStateBrewSwitch = LOW;
-uint8_t currBrewSwitchStateMomentary = LOW;
-int brewSwitchState = kBrewSwitchIdle;
-boolean brewSwitchWasOff = false;
+uint8_t brewSwitchReading = LOW;
+uint8_t currReadingBrewSwitch = LOW;
+bool brewSwitchWasOff = false;
 
-double totalBrewTime = 0;        // total brewtime set in software
-double timeBrewed = 0;           // total brewed time
-double lastBrewTimeMillis = 0;   // for shottimer delay after disarmed button
-double lastBrewTime = 0;
-unsigned long startingTime = 0;  // start time of brew
-boolean brewPIDDisabled = false; // is PID disabled for delay after brew has started?
+// Brew values
+uint8_t featureBrewControl = FEATURE_BREW_CONTROL; // enables control of pumpe and valve
+double targetBrewTime = TARGET_BREW_TIME;          // brew time in s
+double preinfusion = PRE_INFUSION_TIME;            // preinfusion time in s
+double preinfusionPause = PRE_INFUSION_PAUSE_TIME; // preinfusion pause time in s
+double totalTargetBrewTime = 0;                    // total target brew time including preinfusion and preinfusion pause
+double currBrewTime = 0;                           // current running total brewed time
+unsigned long startingTime = 0;                    // start time of brew
+bool brewPIDDisabled = false;                      // is PID disabled for delay after brew has started?
+
+// Backflush values
+int backflushCycles = BACKFLUSH_CYCLES;
+double backflushFillTime = BACKFLUSH_FILL_TIME;
+double backflushFlushTime = BACKFLUSH_FLUSH_TIME;
+int backflushOn = 0;
+int currBackflushCycles = 1;
 
 // Shot timer with or without scale
 #if FEATURE_SCALE == 1
@@ -59,9 +73,9 @@ boolean scaleCalibrationOn = 0;
 boolean scaleTareOn = 0;
 int shottimerCounter = 10;
 float calibrationValue = SCALE_CALIBRATION_FACTOR; // use calibration example to get value
-float weight = 0;                                  // value from HX711
-float weightPreBrew = 0;                           // value of scale before wrew started
-float weightBrew = 0;                              // weight value of brew
+float currReadingWeight = 0;                       // value from HX711
+float prewBrewWeight = 0;                          // value of scale before brew started
+float currBrewWeight = 0;                          // weight value of current brew
 float scaleDelayValue = 2.5;                       // value in gramm that takes still flows onto the scale after brew is stopped
 bool scaleFailure = false;
 const unsigned long intervalWeight = 200;          // weight scale
@@ -77,284 +91,397 @@ HX711_ADC LoadCell2(PIN_HXDAT2, PIN_HXCLK);
  * @brief Toggle or momentary input for Brew Switch
  */
 void checkbrewswitch() {
-    uint8_t brewSwitchReading = brewSwitch->isPressed();
+    static bool loggedEmptyWaterTank = false;
+    brewSwitchReading = brewSwitch->isPressed();
 
+    // Block brewSwitch input when water tank is empty
+    if (machineState == kWaterTankEmpty) {
+
+        if (!loggedEmptyWaterTank && (currBrewSwitchState == kBrewSwitchIdle || currBrewSwitchState == kBrewSwitchPressed)) {
+            LOG(WARNING, "Brew switch input ignored: Water tank empty");
+            loggedEmptyWaterTank = true;
+        }
+        return;
+    }
+    else {
+        loggedEmptyWaterTank = false;
+    }
+
+    // Convert toggle brew switch input to brew switch state
     if (BREWSWITCH_TYPE == Switch::TOGGLE) {
-        currStateBrewSwitch = brewSwitchReading;
-    }
-    else if (BREWSWITCH_TYPE == Switch::MOMENTARY) {
-        if (currBrewSwitchStateMomentary != brewSwitchReading) {
-            currBrewSwitchStateMomentary = brewSwitchReading;
+        if (currReadingBrewSwitch != brewSwitchReading) {
+            currReadingBrewSwitch = brewSwitchReading;
         }
 
-        // Convert momentary brew switch input to brew switch state
-        switch (brewSwitchState) {
+        switch (currBrewSwitchState) {
             case kBrewSwitchIdle:
-                if (currBrewSwitchStateMomentary == HIGH && machineState != kWaterTankEmpty) {
-                    brewSwitchState = kBrewSwitchBrew;
-                    LOG(DEBUG, "brewSwitchState = kBrewSwitchIdle; waiting for brew switch input");
+                if (currReadingBrewSwitch == HIGH) {
+                    currBrewSwitchState = kBrewSwitchShortPressed;
+                    LOG(DEBUG, "Toggle Brew switch is ON -> got to currBrewSwitchState = kBrewSwitchShortPressed");
                 }
                 break;
 
-            case kBrewSwitchBrew:
-                // Brew switch short pressed - start brew
-                if (currBrewSwitchStateMomentary == LOW) {
-                    // Brew trigger
-                    currStateBrewSwitch = HIGH;
-                    brewSwitchState = kBrewSwitchBrewAbort;
-                    LOG(DEBUG, "brewSwitchState = kBrewSwitchBrew; brew switch short pressed - start Brew");
+            case kBrewSwitchShortPressed:
+                if (currReadingBrewSwitch == LOW) {
+                    currBrewSwitchState = kBrewSwitchIdle;
+                    LOG(DEBUG, "Toggle Brew switch is OFF -> got to currBrewSwitchState = kBrewSwitchIdle");
                 }
-
-                // Brew switch more than brewSwitchMomentaryLongPress pressed - start flushing
-                if (currBrewSwitchStateMomentary == HIGH && brewSwitch->longPressDetected() && machineState != kWaterTankEmpty) {
-                    brewSwitchState = kBrewSwitchFlushOff;
-                    valveRelay.on();
-                    pumpRelay.on();
-                    startingTime = millis();
-                    LOG(DEBUG, "brewSwitchState = kBrewSwitchBrew: brew switch long pressed - start flushing");
+                else if ((currBrewState == kBrewFinished) || (currBackflushState == kBackflushFinished)) {
+                    currBrewSwitchState = kBrewSwitchWaitForRelease;
+                    LOG(DEBUG, "Brew reached target or backflush done -> got to currBrewSwitchState = kBrewSwitchWaitForRelease");
                 }
                 break;
 
-            case kBrewSwitchBrewAbort:
-                // Brew switch got short pressed while brew is running - abort brew
-                if ((currBrewSwitchStateMomentary == HIGH && currStateBrewSwitch == HIGH) || (machineState == kShotTimerAfterBrew) || (backflushState == kBackflushWaitBrewswitchOff)) {
-                    currStateBrewSwitch = LOW;
-                    brewSwitchState = kBrewSwitchReset;
-                    LOG(DEBUG, "brewSwitchState = kBrewSwitchBrewAbort: brew switch short pressed - stop brew");
+            case kBrewSwitchWaitForRelease:
+                if (currReadingBrewSwitch == LOW) {
+                    currBrewSwitchState = kBrewSwitchIdle;
+                    LOG(DEBUG, "Brew switch reset -> got to currBrewSwitchState = kBrewSwitchIdle");
                 }
                 break;
 
-            case kBrewSwitchFlushOff:
-                // Brew switch got released - stop flushing
-                if (currBrewSwitchStateMomentary == LOW && currStateBrewSwitch == LOW) {
-                    brewSwitchState = kBrewSwitchReset;
-                    LOG(DEBUG, "brewswitchTriggerCase = kBrewSwitchFlushOff: brew switch long press released - stop flushing");
-                    valveRelay.off();
-                    pumpRelay.off();
-                }
-                break;
+            default:
 
-            case kBrewSwitchReset:
-                // Brew switch is released - go back to start and wait for next brew switch input
-                if (currBrewSwitchStateMomentary == LOW) {
-                    brewSwitchState = kBrewSwitchIdle;
-                    LOG(DEBUG, "brewSwitchState = kBrewSwitchReset: brew switch released - go to kBrewSwitchIdle ");
-                }
+                currBrewSwitchState = kBrewSwitchIdle;
+                LOG(DEBUG, "Unexpected switch state -> currBrewSwitchState = kBrewSwitchIdle");
                 break;
         }
     }
+
+    // Convert momentary brew switch input to brew switch state
+    else if (BREWSWITCH_TYPE == Switch::MOMENTARY) {
+        if (currReadingBrewSwitch != brewSwitchReading) {
+            currReadingBrewSwitch = brewSwitchReading;
+        }
+
+        switch (currBrewSwitchState) {
+            case kBrewSwitchIdle:
+                if (currReadingBrewSwitch == HIGH) {
+                    currBrewSwitchState = kBrewSwitchPressed;
+                    LOG(DEBUG, "Brew switch press detected -> got to currBrewSwitchState = kBrewSwitchPressed");
+                }
+                break;
+
+            case kBrewSwitchPressed:                // Brew switch pressed - check for short or long press
+                if (currReadingBrewSwitch == LOW) { // Brew switch short press detected
+                    currBrewSwitchState = kBrewSwitchShortPressed;
+                    LOG(DEBUG, "Brew switch short press detected -> got to currBrewSwitchState = kBrewSwitchShortPressed; start brew");
+                }
+                else if (currReadingBrewSwitch == HIGH && brewSwitch->longPressDetected()) { // Brew switch long press detected
+                    currBrewSwitchState = kBrewSwitchLongPressed;
+                    LOG(DEBUG, "Brew switch long press detected -> got to currBrewSwitchState = kBrewSwitchLongPressed; start manual flush");
+                }
+                break;
+
+            case kBrewSwitchShortPressed:
+                if (currReadingBrewSwitch == HIGH) { // Brew switch short press detected while brew is running - abort brew
+                    currBrewSwitchState = kBrewSwitchWaitForRelease;
+                    LOG(DEBUG, "Brew switch short press detected -> got to currBrewSwitchState = kBrewSwitchWaitForRelease; brew or backflush stopped manually");
+                }
+                else if ((currBrewState == kBrewFinished) || (currBackflushState == kBackflushFinished)) { // Brew reached target and stopped or blackflush cycle done
+                    currBrewSwitchState = kBrewSwitchWaitForRelease;
+                    LOG(DEBUG, "Brew reached target or backflush done -> got to currBrewSwitchState = kBrewSwitchWaitForRelease");
+                }
+                break;
+
+            case kBrewSwitchLongPressed:
+                if (currReadingBrewSwitch == LOW) { // Brew switch got released after long press detected - reset brewswitch
+                    currBrewSwitchState = kBrewSwitchWaitForRelease;
+                    LOG(DEBUG, "Brew switch long press released -> got to currBrewSwitchState = kBrewSwitchWaitForRelease; stop manual flush");
+                }
+                break;
+
+            case kBrewSwitchWaitForRelease: // wait for brew switch got released
+                if (currReadingBrewSwitch == LOW) {
+                    currBrewSwitchState = kBrewSwitchIdle;
+                    LOG(DEBUG, "Brew switch reset -> got to currBrewSwitchState = kBrewSwitchIdle");
+                }
+                break;
+
+            default:
+                currBrewSwitchState = kBrewSwitchIdle;
+                LOG(DEBUG, "Unexpected switch state -> currBrewSwitchState = kBrewSwitchIdle");
+                break;
+        }
+    }
+}
+
+/**
+ * @brief Brew process handeling including timer and state machine for brew-by-time and brew-by-weight
+ * @return true if brew is running, false otherwise
+ */
+bool brew() {
+    unsigned long currentMillisTemp = millis();
+    checkbrewswitch();
+
+    // abort function for state machine from every state
+    if (currBrewSwitchState == kBrewSwitchIdle && currBrewState > kBrewIdle && currBrewState < kBrewFinished) {
+        if (currBrewState != kBrewFinished) {
+            LOG(INFO, "Brew stopped manually");
+        }
+        currBrewState = kBrewFinished;
+    }
+    // calculated brew time while brew is running
+    if (currBrewState > kBrewIdle && currBrewState < kBrewFinished) {
+        currBrewTime = currentMillisTemp - startingTime;
+    }
+
+    if (featureBrewControl) { // brew-by-time and brew-by-weight
+
+        // check if brewswitch was turned off after a brew; Brew only runs once even brewswitch is still pressed
+        if (currBrewSwitchState == kBrewSwitchIdle) {
+            brewSwitchWasOff = true;
+        }
+
+        // set brew time every cycle, in case changes are done during brew
+        if (targetBrewTime > 0) {
+            totalTargetBrewTime = (preinfusion * 1000) + (preinfusionPause * 1000) + (targetBrewTime * 1000);
+        }
+        else {
+            // Stop by time deactivated --> totalTargetBrewTime = 0
+            totalTargetBrewTime = 0;
+        }
+
+        // state machine for brew
+        switch (currBrewState) {
+            case kBrewIdle:           // waiting step for brew switch turning on
+                if (currBrewSwitchState == kBrewSwitchShortPressed && brewSwitchWasOff && backflushOn == 0 && machineState != kBackflush) {
+                    startingTime = millis();
+                    currBrewTime = 0; // reset currBrewTime, last brew is still stored
+                    LOG(INFO, "Brew started");
+
+                    if (preinfusionPause == 0 || preinfusion == 0) {
+                        LOG(INFO, "Brew running");
+                        currBrewState = kBrewRunning;
+                    }
+                    else {
+                        LOG(INFO, "Preinfusion running");
+                        currBrewState = kPreinfusion;
+                    }
+                }
+
+                break;
+
+            case kPreinfusion:
+                valveRelay.on();
+                pumpRelay.on();
+
+                if (currBrewTime > (preinfusion * 1000)) {
+                    LOG(INFO, "Preinfusion pause running");
+                    currBrewState = kPreinfusionPause;
+                }
+
+                break;
+
+            case kPreinfusionPause:
+                valveRelay.on();
+                pumpRelay.off();
+
+                if (currBrewTime > ((preinfusion + preinfusionPause) * 1000)) {
+                    LOG(INFO, "Brew running");
+                    currBrewState = kBrewRunning;
+                }
+
+                break;
+
+            case kBrewRunning:
+                valveRelay.on();
+                pumpRelay.on();
+
+                // stop brew if target-time is reached --> No stop if stop by time is deactivated via Parameter (0)
+                if ((currBrewTime > totalTargetBrewTime) && ((targetBrewTime > 0))) {
+                    LOG(INFO, "Brew reached time target");
+                    currBrewState = kBrewFinished;
+                }
+#if (FEATURE_SCALE == 1)
+                // stop brew if target-weight is reached --> No stop if stop by weight is deactivated via Parameter (0)
+                else if (((FEATURE_SCALE == 1) && (currBrewWeight > targetBrewWeight)) && (targetBrewWeight > 0)) {
+                    LOG(INFO, "Brew reached weight target");
+                    currBrewState = kBrewFinished;
+                }
+#endif
+
+                break;
+
+            case kBrewFinished:
+                valveRelay.off();
+                pumpRelay.off();
+                currentMillisTemp = 0;
+                brewSwitchWasOff = false;
+                LOG(INFO, "Brew finished");
+                LOGF(INFO, "Shot time: %4.1f s", currBrewTime / 1000);
+                LOG(INFO, "Brew idle");
+                currBrewState = kBrewIdle;
+
+                break;
+
+            default:
+                currBrewState = kBrewIdle;
+                LOG(DEBUG, "Unexpected brew state -> currBrewState = kBrewIdle");
+
+                break;
+        }
+    }
+    else {                            // brewControlOn == 0, only brew time
+
+        switch (currBrewState) {
+            case kBrewIdle:           // waiting step for brew switch turning on
+                if (currBrewSwitchState == kBrewSwitchShortPressed) {
+                    startingTime = millis();
+                    currBrewTime = 0; // reset timeBrewed, last brew is still stored
+                    LOG(INFO, "Brew timer started");
+                    currBrewState = kBrewRunning;
+                }
+
+                break;
+
+            case kBrewRunning:
+                if (currBrewSwitchState == kBrewSwitchIdle && currBrewState == kBrewRunning) {
+                    currBrewState = kBrewFinished;
+                }
+
+                break;
+
+            case kBrewFinished:
+                currentMillisTemp = 0;
+                LOG(INFO, "Brew finished");
+                LOGF(INFO, "Shot time: %4.1f s", currBrewTime / 1000);
+                LOG(INFO, "Brew idle");
+                currBrewState = kBrewIdle;
+
+                break;
+
+            default:
+                currBrewState = kBrewIdle;
+                LOG(DEBUG, "Unexpected brew state -> currBrewState = kBrewIdle");
+
+                break;
+        }
+    }
+    return (currBrewState != kBrewIdle && currBrewState != kBrewFinished);
+}
+
+/**
+ * @brief manual grouphead flush
+ * @return true if manual flush is running, false otherwise
+ */
+bool manualFlush() {
+    unsigned long currentMillisTemp = millis();
+    checkbrewswitch();
+    if (currManualFlushState == kManualFlushRunning) {
+        currBrewTime = currentMillisTemp - startingTime;
+    }
+
+    switch (currManualFlushState) {
+        case kManualFlushIdle:
+            if (currBrewSwitchState == kBrewSwitchLongPressed) {
+                startingTime = millis();
+                valveRelay.on();
+                pumpRelay.on();
+                LOG(INFO, "Manual flush started");
+                currManualFlushState = kManualFlushRunning;
+            }
+            break;
+
+        case kManualFlushRunning:
+            if (currBrewSwitchState != kBrewSwitchLongPressed) {
+                valveRelay.off();
+                pumpRelay.off();
+                LOG(INFO, "Manual flush stopped");
+                LOGF(INFO, "Manual flush time: %4.1f s", currBrewTime / 1000);
+                currManualFlushState = kManualFlushIdle;
+            }
+            break;
+
+        default:
+            currManualFlushState = kManualFlushIdle;
+            LOG(DEBUG, "Unexpected manual flush state -> currManualFlushState = kManualFlushIdle");
+
+            break;
+    }
+    return (currManualFlushState == kManualFlushRunning);
 }
 
 /**
  * @brief Backflush
  */
 void backflush() {
-    if (backflushState != kBackflushWaitBrewswitchOn && backflushOn == 0) {
-        backflushState = kBackflushWaitBrewswitchOff; // Force reset in case backflushOn is reset during backflush!
-        LOG(INFO, "Backflush: Disabled via Webinterface");
+    checkbrewswitch();
+    if (currBackflushState != kBackflushIdle && backflushOn == 0) {
+        currBackflushState = kBackflushFinished; // Force reset in case backflushOn is reset during backflush!
+        LOG(INFO, "Backflush: Disabled via webinterface");
     }
     else if (offlineMode == 1 || currBrewState > kBrewIdle || backflushCycles <= 0 || backflushOn == 0) {
         return;
     }
 
-    if (bPID.GetMode() == 1) { // Deactivate PID
-        bPID.SetMode(0);
-        pidOutput = 0;
+    // abort function for state machine from every state
+    if (currBrewSwitchState == kBrewSwitchIdle && currBackflushState > kBackflushIdle && currBackflushState < kBackflushFinished) {
+        currBackflushState = kBackflushFinished;
+        if (currBackflushState != kBackflushFinished) {
+            LOG(INFO, "Backflush stopped manually");
+        }
     }
 
-    heaterRelay.off(); // Stop heating
-
-    checkbrewswitch();
-
-    if (currStateBrewSwitch == LOW && backflushState != kBackflushWaitBrewswitchOn) { // Abort function for state machine from every state
-        backflushState = kBackflushWaitBrewswitchOff;
+    // check if brewswitch was turned off after a backflush; Backflush only runs once even brewswitch is still pressed
+    if (currBrewSwitchState == kBrewSwitchIdle) {
+        brewSwitchWasOff = true;
     }
 
     // State machine for backflush
-    switch (backflushState) {
-        case kBackflushWaitBrewswitchOn:
-            if (currStateBrewSwitch == HIGH && backflushOn) {
+    switch (currBackflushState) {
+        case kBackflushIdle:
+            if (currBrewSwitchState == kBrewSwitchShortPressed && backflushOn && brewSwitchWasOff) {
                 startingTime = millis();
-                backflushState = kBackflushFillingStart;
+                valveRelay.on();
+                pumpRelay.on();
+                LOGF(INFO, "Start backflush cycle %d", currBackflushCycles);
+                LOG(INFO, "Backflush: filling portafilter");
+                currBackflushState = kBackflushFilling;
             }
-
-            break;
-
-        case kBackflushFillingStart:
-            LOG(INFO, "Backflush: Portafilter filling...");
-            valveRelay.on();
-            pumpRelay.on();
-            backflushState = kBackflushFilling;
 
             break;
 
         case kBackflushFilling:
             if (millis() - startingTime > (backflushFillTime * 1000)) {
                 startingTime = millis();
-                backflushState = kBackflushFlushingStart;
+                valveRelay.off();
+                pumpRelay.off();
+                LOG(INFO, "Backflush: flushing into drip tray");
+                currBackflushState = kBackflushFlushing;
             }
-
-            break;
-
-        case kBackflushFlushingStart:
-            LOG(INFO, "Backflush: Flushing to drip tray...");
-            valveRelay.off();
-            pumpRelay.off();
-            currBackflushCycles++;
-            backflushState = kBackflushFlushing;
-
             break;
 
         case kBackflushFlushing:
-            if (millis() - startingTime > (backflushFlushTime * 1000) && currBackflushCycles < backflushCycles) {
-                startingTime = millis();
-                backflushState = kBackflushFillingStart;
-            }
-            else if (currBackflushCycles >= backflushCycles) {
-                backflushState = kBackflushWaitBrewswitchOff;
-            }
-
-            break;
-
-        case kBackflushWaitBrewswitchOff:
-            if (currStateBrewSwitch == LOW) {
-                LOG(INFO, "Backflush: Finished!");
-                valveRelay.off();
-                pumpRelay.off();
-                currBackflushCycles = 0;
-                backflushState = kBackflushWaitBrewswitchOn;
-            }
-
-            break;
-    }
-}
-
-#if (FEATURE_BREWCONTROL == 1)
-/**
- * @brief Time base brew mode
- */
-void brew() {
-    unsigned long currentMillisTemp = millis();
-    checkbrewswitch();
-
-    if (currStateBrewSwitch == LOW && currBrewState > kBrewIdle) {
-        // abort function for state machine from every state
-        LOG(INFO, "Brew stopped manually");
-        currBrewState = kWaitBrewOff;
-    }
-
-    if (currBrewState > kBrewIdle && currBrewState < kWaitBrewOff || brewSwitchState == kBrewSwitchFlushOff) {
-        timeBrewed = currentMillisTemp - startingTime;
-    }
-
-    if (currStateBrewSwitch == LOW) {
-        // check if brewswitch was turned off at least once, last time,
-        brewSwitchWasOff = true;
-    }
-
-    if (brewTime > 0) {
-        totalBrewTime = (preinfusion * 1000) + (preinfusionPause * 1000) + (brewTime * 1000); // running every cycle, in case changes are done during brew
-    }
-    else {
-        // Stop by time deactivated --> brewTime = 0
-        totalBrewTime = 0;
-    }
-
-    // state machine for brew
-    switch (currBrewState) {
-        case kBrewIdle: // waiting step for brew switch turning on
-            if (currStateBrewSwitch == HIGH && backflushState == 10 && backflushOn == 0 && brewSwitchWasOff && machineState != kWaterTankEmpty) {
-                startingTime = millis();
-
-                if (preinfusionPause == 0 || preinfusion == 0) {
-                    currBrewState = kBrewRunning;
+            if (millis() - startingTime > (backflushFlushTime * 1000)) {
+                if (currBackflushCycles < backflushCycles) {
+                    startingTime = millis();
+                    valveRelay.on();
+                    pumpRelay.on();
+                    currBackflushCycles++;
+                    LOGF(INFO, "Backflush: next backflush cycle %d", currBackflushCycles);
+                    LOG(INFO, "Backflush: filling portafilter");
+                    currBackflushState = kBackflushFilling;
                 }
                 else {
-                    currBrewState = kPreinfusion;
+                    currBackflushState = kBackflushFinished;
                 }
             }
-            else {
-                backflush();
-            }
-
             break;
 
-        case kPreinfusion: // preinfusioon
-            LOG(INFO, "Preinfusion");
-            valveRelay.on();
-            pumpRelay.on();
-            currBrewState = kWaitPreinfusion;
-
-            break;
-
-        case kWaitPreinfusion: // waiting time preinfusion
-            if (timeBrewed > (preinfusion * 1000)) {
-                currBrewState = kPreinfusionPause;
-            }
-
-            break;
-
-        case kPreinfusionPause: // preinfusion pause
-            LOG(INFO, "Preinfusion pause");
-            valveRelay.on();
-            pumpRelay.off();
-            currBrewState = kWaitPreinfusionPause;
-
-            break;
-
-        case kWaitPreinfusionPause: // waiting time preinfusion pause
-            if (timeBrewed > ((preinfusion * 1000) + (preinfusionPause * 1000))) {
-                currBrewState = kBrewRunning;
-            }
-
-            break;
-
-        case kBrewRunning: // brew running
-            LOG(INFO, "Brew started");
-            valveRelay.on();
-            pumpRelay.on();
-            currBrewState = kWaitBrew;
-
-            break;
-
-        case kWaitBrew: // waiting time or weight brew
-            lastBrewTime = timeBrewed;
-
-            // stop brew if target-time is reached --> No stop if stop by time is deactivated via Parameter (0)
-            if ((timeBrewed > totalBrewTime) && ((brewTime > 0))) {
-                currBrewState = kBrewFinished;
-            }
-#if (FEATURE_SCALE == 1)
-            // stop brew if target-weight is reached --> No stop if stop by weight is deactivated via Parameter (0)
-            else if (((FEATURE_SCALE == 1) && (weightBrew > weightSetpoint)) && (weightSetpoint > 0)) {
-                currBrewState = kBrewFinished;
-            }
-#endif
-
-            break;
-
-        case kBrewFinished: // brew finished
-            LOG(INFO, "Brew stopped");
+        case kBackflushFinished:
             valveRelay.off();
             pumpRelay.off();
-            currBrewState = kWaitBrewOff;
+            LOGF(INFO, "Backflush finished after %d cycles", currBackflushCycles);
+            currBackflushCycles = 1;
+            brewSwitchWasOff = false;
+            currBackflushState = kBackflushIdle;
 
             break;
 
-        case kWaitBrewOff: // waiting for brewswitch off position
-            if (currStateBrewSwitch == LOW) {
-                valveRelay.off();
-                pumpRelay.off();
-
-                // disarmed button
-                currentMillisTemp = 0;
-                brewDetected = 0;          // rearm brewDetection
-                currBrewState = kBrewIdle;
-                lastBrewTime = timeBrewed; // store brewtime to show in Shottimer after brew is finished
-                timeBrewed = 0;
-            }
+        default:
+            currBackflushState = kBackflushIdle;
+            LOG(DEBUG, "Unexpected backflush state -> currBackflushState = kBackflushIdle");
 
             break;
     }
 }
-#endif

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -20,77 +20,79 @@ int writeSysParamsToStorage(void);
 #define STR(x)        STR_HELPER(x)
 
 // default parameters
-#define SETPOINT                  95     // brew temperature setpoint
-#define TEMPOFFSET                0      // brew temperature setpoint
-#define STEAMSETPOINT             120    // steam temperature setpoint
-#define SCALE_CALIBRATION_FACTOR  1.00   // Raw data is divided by this value to convert to readable data
-#define SCALE2_CALIBRATION_FACTOR 1.00   // Raw data is divided by this value to convert to readable data
-#define SCALE_KNOWN_WEIGHT        267.00 // Calibration weight for scale (weight of the tray)
-#define AGGKP                     62     // PID Kp (regular phase)
-#define AGGTN                     52     // PID Tn (regular phase)
-#define AGGTV                     11.5   // PID Tv (regular phase)
-#define AGGIMAX                   55     // PID Integrator Max (regular phase)
-#define STEAMKP                   150    // PID kp (steam phase)
-#define AGGBKP                    50     // PID Kp (brew detection phase)
-#define AGGBTN                    0      // PID Tn (brew detection phase)
-#define AGGBTV                    20     // PID Tv (brew detection phase)
-#define BREW_TIME                 25     // brew time in seconds (only used if pump is being controlled)
-#define BREW_SW_TIME              25     // keep brew PID params for this many seconds after detection (only for software BD)
-#define BREW_PID_DELAY            10     // delay until enabling PID controller during brew (no heating during this time)
-#define BD_SENSITIVITY            120    // brew detection sensitivity, be careful: if too low, then there is the risk of wrong brew detection and rising temperature
-#define PRE_INFUSION_TIME         2      // pre-infusion time in seconds
-#define PRE_INFUSION_PAUSE_TIME   5      // pre-infusion pause time in seconds
-#define SCALE_WEIGHTSETPOINT      30     // Target weight in grams
-#define WIFI_CREDENTIALS_SAVED    0      // Flag if wifi setup is done. 0: not set up, 1: credentials set up via wifi manager
-#define STANDBY_MODE_ON           0      // Standby mode off by default
-#define STANDBY_MODE_TIME         30     // Time in minutes until the heater is turned off
-#define BACKFLUSH_CYCLES          5      // number of cycles the backflush should run
-#define BACKFLUSH_FILL_TIME       5      // time in seconds the pump is running during backflush
-#define BACKFLUSH_FLUSH_TIME      10     // time in seconds the 3-way valve is open during backflush
+#define SETPOINT                              95     // brew temperature setpoint
+#define TEMPOFFSET                            0      // brew temperature setpoint
+#define STEAMSETPOINT                         120    // steam temperature setpoint
+#define SCALE_CALIBRATION_FACTOR              1.00   // Raw data is divided by this value to convert to readable data
+#define SCALE2_CALIBRATION_FACTOR             1.00   // Raw data is divided by this value to convert to readable data
+#define SCALE_KNOWN_WEIGHT                    267.00 // Calibration weight for scale (weight of the tray)
+#define AGGKP                                 62     // PID Kp (regular phase)
+#define AGGTN                                 52     // PID Tn (regular phase)
+#define AGGTV                                 11.5   // PID Tv (regular phase)
+#define AGGIMAX                               55     // PID Integrator Max (regular phase)
+#define STARTKP                               45     // PID Kp (coldstart phase)
+#define STARTTN                               130    // PID Tn (coldstart phase)
+#define STEAMKP                               150    // PID kp (steam phase)
+#define AGGBKP                                50     // PID Kp (brew detection phase)
+#define AGGBTN                                0      // PID Tn (brew detection phase)
+#define AGGBTV                                20     // PID Tv (brew detection phase)
+#define TARGET_BREW_TIME                      25     // brew time in seconds (only used if pump is being controlled)
+#define BREW_PID_DELAY                        10     // delay until enabling PID controller during brew (no heating during this time)
+#define PRE_INFUSION_TIME                     2      // pre-infusion time in seconds
+#define PRE_INFUSION_PAUSE_TIME               5      // pre-infusion pause time in seconds
+#define TARGET_BREW_WEIGHT                    30     // Target weight in grams
+#define WIFI_CREDENTIALS_SAVED                0      // Flag if wifi setup is done. 0: not set up, 1: credentials set up via wifi manager
+#define STANDBY_MODE_ON                       0      // Standby mode off by default
+#define STANDBY_MODE_TIME                     30     // Time in minutes until the heater is turned off
+#define BACKFLUSH_CYCLES                      5      // number of cycles the backflush should run
+#define BACKFLUSH_FILL_TIME                   5      // time in seconds the pump is running during backflush
+#define BACKFLUSH_FLUSH_TIME                  10     // time in seconds the 3-way valve is open during backflush
+#define FEATURE_BREW_CONTROL                  0      // enables function to control pump and solenoid valve
+#define FEATURE_FULLSCREEN_BREW_TIMER         0      // enables full screen brew timer
+#define FEATURE_FULLSCREEN_MANUAL_FLUSH_TIMER 0      // enables full screen manual flush timer
+#define POST_BREW_TIMER_DURATION              3      // time in seconds that brew timer will be shown after brew finished
+#define FEATURE_HEATING_LOGO                  1      // enables full screen logo if mashine is heating
+#define FEATURE_PID_OFF_LOGO                  1      // enables full screen logo if pid is switched off
 
-#define PID_KP_REGULAR_MIN       0
-#define PID_KP_REGULAR_MAX       999
-#define PID_TN_REGULAR_MIN       0
-#define PID_TN_REGULAR_MAX       999
-#define PID_TV_REGULAR_MIN       0
-#define PID_TV_REGULAR_MAX       999
-#define PID_I_MAX_REGULAR_MIN    0
-#define PID_I_MAX_REGULAR_MAX    999
-#define PID_KP_BD_MIN            0
-#define PID_KP_BD_MAX            999
-#define PID_TN_BD_MIN            0
-#define PID_TN_BD_MAX            999
-#define PID_TV_BD_MIN            0
-#define PID_TV_BD_MAX            999
-#define BREW_SETPOINT_MIN        20
-#define BREW_SETPOINT_MAX        110
-#define STEAM_SETPOINT_MIN       100
-#define STEAM_SETPOINT_MAX       140
-#define BREW_TEMP_OFFSET_MIN     0
-#define BREW_TEMP_OFFSET_MAX     20
-#define BREW_TEMP_TIME_MIN       1
-#define BREW_TEMP_TIME_MAX       180
-#define BREW_TIME_MIN            0
-#define BREW_TIME_MAX            180
-#define BREW_PID_DELAY_MIN       0
-#define BREW_PID_DELAY_MAX       60
-#define BREW_SW_TIME_MIN         1
-#define BREW_SW_TIME_MAX         180
-#define BD_THRESHOLD_MIN         0
-#define BD_THRESHOLD_MAX         999
-#define PRE_INFUSION_TIME_MIN    0
-#define PRE_INFUSION_TIME_MAX    60
-#define PRE_INFUSION_PAUSE_MIN   0
-#define PRE_INFUSION_PAUSE_MAX   60
-#define WEIGHTSETPOINT_MIN       0
-#define WEIGHTSETPOINT_MAX       500
-#define PID_KP_STEAM_MIN         0
-#define PID_KP_STEAM_MAX         500
-#define STANDBY_MODE_TIME_MIN    30
-#define STANDBY_MODE_TIME_MAX    120
-#define BACKFLUSH_CYCLES_MIN     2
-#define BACKFLUSH_CYCLES_MAX     20
-#define BACKFLUSH_FILL_TIME_MIN  5
-#define BACKFLUSH_FILL_TIME_MAX  20
-#define BACKFLUSH_FLUSH_TIME_MIN 5
-#define BACKFLUSH_FLUSH_TIME_MAX 20
+#define PID_KP_REGULAR_MIN           0
+#define PID_KP_REGULAR_MAX           999
+#define PID_TN_REGULAR_MIN           0
+#define PID_TN_REGULAR_MAX           999
+#define PID_TV_REGULAR_MIN           0
+#define PID_TV_REGULAR_MAX           999
+#define PID_I_MAX_REGULAR_MIN        0
+#define PID_I_MAX_REGULAR_MAX        999
+#define PID_KP_BD_MIN                0
+#define PID_KP_BD_MAX                999
+#define PID_TN_BD_MIN                0
+#define PID_TN_BD_MAX                999
+#define PID_TV_BD_MIN                0
+#define PID_TV_BD_MAX                999
+#define BREW_SETPOINT_MIN            20
+#define BREW_SETPOINT_MAX            110
+#define STEAM_SETPOINT_MIN           100
+#define STEAM_SETPOINT_MAX           140
+#define BREW_TEMP_OFFSET_MIN         0
+#define BREW_TEMP_OFFSET_MAX         20
+#define TARGET_BREW_TIME_MIN         0
+#define TARGET_BREW_TIME_MAX         180
+#define BREW_PID_DELAY_MIN           0
+#define BREW_PID_DELAY_MAX           60
+#define PRE_INFUSION_TIME_MIN        0
+#define PRE_INFUSION_TIME_MAX        60
+#define PRE_INFUSION_PAUSE_MIN       0
+#define PRE_INFUSION_PAUSE_MAX       60
+#define TARGET_BREW_WEIGHT_MIN       0
+#define TARGET_BREW_WEIGHT_MAX       500
+#define PID_KP_STEAM_MIN             0
+#define PID_KP_STEAM_MAX             500
+#define STANDBY_MODE_TIME_MIN        30
+#define STANDBY_MODE_TIME_MAX        120
+#define BACKFLUSH_CYCLES_MIN         2
+#define BACKFLUSH_CYCLES_MAX         20
+#define BACKFLUSH_FILL_TIME_MIN      5
+#define BACKFLUSH_FILL_TIME_MAX      20
+#define BACKFLUSH_FLUSH_TIME_MIN     5
+#define BACKFLUSH_FLUSH_TIME_MAX     20
+#define POST_BREW_TIMER_DURATION_MIN 0
+#define POST_BREW_TIMER_DURATION_MAX 60

--- a/src/display/bitmaps.h
+++ b/src/display/bitmaps.h
@@ -9,10 +9,6 @@
 
 #define CleverCoffee_Logo_width      40
 #define CleverCoffee_Logo_height     40
-#define Rancilio_Silvia_Logo_width   52
-#define Rancilio_Silvia_Logo_height  49
-#define Gaggia_Classic_Logo_width    46
-#define Gaggia_Classic_Logo_height   49
 #define Heating_Logo_width           40
 #define Heating_Logo_height          40
 #define Off_Logo_width               52

--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -139,9 +139,110 @@ void displayTemperature(int x, int y) {
 }
 
 /**
- * @brief Draw the brew time at given position
+ * @brief determines if brew timer should be visible; postBrewTimerDuration defines how long the timer after the brew is shown
+ * @return true if timer should be visible, false otherwise
  */
-void displayBrewtime(int x, int y, double brewtime) {
+bool shouldDisplayBrewTimer() {
+
+    enum BrewTimerState {
+        kBrewTimerIdle = 10,
+        kBrewTimerRunning = 20,
+        kBrewTimerPostBrew = 30
+    };
+
+    static BrewTimerState currBrewTimerState = kBrewTimerIdle;
+
+    static uint32_t brewEndTime = 0;
+
+    switch (currBrewTimerState) {
+        case kBrewTimerIdle:
+            if (brew()) {
+                currBrewTimerState = kBrewTimerRunning;
+            }
+            break;
+
+        case kBrewTimerRunning:
+            if (!brew()) {
+                currBrewTimerState = kBrewTimerPostBrew;
+                brewEndTime = millis();
+            }
+            break;
+
+        case kBrewTimerPostBrew:
+            if ((millis() - brewEndTime) > (uint32_t)(postBrewTimerDuration * 1000)) {
+                currBrewTimerState = kBrewTimerIdle;
+            }
+            break;
+    }
+
+    return (currBrewTimerState != kBrewTimerIdle);
+}
+
+/**
+ * @brief Draw current brew time with optional brew target time at given position
+ *
+ * Shows the current brew time in seconds. If a target time (totalTargetBrewTime) is provided (> 0), it is displayed alongside the current time.
+ *
+ * @param x              Horizontal position to start drawing
+ * @param y              Vertical position to start drawing
+ * @param label          Text label to display before the time
+ * @param currBrewTime     Current brewed time in milliseconds
+ * @param totalTargetBrewTime  Target brew time in milliseconds (optional, default -1)
+ */
+void displayBrewTime(int x, int y, const char* label, double currBrewTime, double totalTargetBrewTime = -1) {
+    u8g2.setCursor(x, y);
+    u8g2.print(label);
+    u8g2.setCursor(x + 50, y);
+    u8g2.print(currBrewTime / 1000, 0);
+
+    if (totalTargetBrewTime > 0) {
+        u8g2.print("/");
+        u8g2.print(totalTargetBrewTime / 1000, 0);
+    }
+
+    u8g2.print(" s");
+}
+
+/**
+ * @brief Draw the current weight with error handling and target indicators at given position
+ *
+ * If the scale reports an error, "fault" is shown on the display instead of weight.
+ * Otherwise, the function displays the current weight.
+ * If a target weight (setpoint) is set (> 0), it will be displayed alongside the current weight.
+ * This function is intended to provide the status of the scales during brewing, flushing, or other machine states.
+ *
+ * @param x        Horizontal position to start drawing
+ * @param y        Vertical position to start drawing
+ * @param weight   Current measured weight to display
+ * @param setpoint Target weight to display alongside current weight (optional, default -1)
+ * @param fault    Indicates if the scale has an error (optional, default false)
+ */
+void displayBrewWeight(int x, int y, float weight, float setpoint = -1, bool fault = false) {
+    if (fault) {
+        u8g2.setCursor(x, y);
+        u8g2.print(langstring_weight);
+        u8g2.setCursor(x + 50, y);
+        u8g2.print(langstring_scale_Failure);
+        return;
+    }
+
+    u8g2.setCursor(x, y);
+    u8g2.print(langstring_weight);
+    u8g2.setCursor(x + 50, y);
+    u8g2.print(weight, 0);
+
+    if (setpoint > 0) {
+        u8g2.print("/");
+        u8g2.print(setpoint, 0);
+    }
+
+    u8g2.print(" g");
+}
+
+/**
+ * @brief Draw the brew time at given position (fullscreen brewtimer)
+ */
+void displayBrewtimeFs(int x, int y, double brewtime) {
     u8g2.setFont(u8g2_font_fub25_tf);
 
     if (brewtime < 10000.000) {
@@ -234,66 +335,53 @@ void displayLogo(String displaymessagetext, String displaymessagetext2) {
 }
 
 /**
- * @brief display shot timer
+ * @brief display fullscreen brew timer
  */
-bool displayShottimer() {
-    if (FEATURE_SHOTTIMER == 0) {
+bool displayFullscreenBrewTimer() {
+    if (featureFullscreenBrewTimer == 0) {
         return false;
     }
 
-    if (machineState == kBrew || brewSwitchState == kBrewSwitchFlushOff) {
-        u8g2.clearBuffer();
-
-        if (brewSwitchState != kBrewSwitchFlushOff) {
-            u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
-        }
-        else {
-            u8g2.drawXBMP(0, 12, Manual_Flush_Logo_width, Manual_Flush_Logo_height, Manual_Flush_Logo);
-        }
-
-#if (FEATURE_SCALE == 1)
-        u8g2.setFont(u8g2_font_profont22_tf);
-        u8g2.setCursor(64, 15);
-        u8g2.print(timeBrewed / 1000, 1);
-        u8g2.print("s");
-        u8g2.setCursor(64, 38);
-        u8g2.print(weightBrew, 1);
-        u8g2.print("g");
-        u8g2.setFont(u8g2_font_profont11_tf);
-#else
-        displayBrewtime(48, 25, timeBrewed);
-#endif
-
-        displayWaterIcon(119, 1);
-        u8g2.sendBuffer();
-        return true;
-    }
-
-    /* if the totalBrewTime is reached automatically,
-     * nothing should be done, otherwise wrong time is displayed
-     * because the switch is pressed later than totalBrewTime
-     */
-    else if (machineState == kShotTimerAfterBrew && brewSwitchState != kBrewSwitchFlushOff) {
+    if (shouldDisplayBrewTimer()) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
-
 #if (FEATURE_SCALE == 1)
         u8g2.setFont(u8g2_font_profont22_tf);
         u8g2.setCursor(64, 15);
-        u8g2.print(lastBrewTime / 1000, 1);
+        u8g2.print(currBrewTime / 1000, 1);
         u8g2.print("s");
         u8g2.setCursor(64, 38);
-        u8g2.print(weightBrew, 1);
+        u8g2.print(currBrewWeight, 1);
         u8g2.print("g");
         u8g2.setFont(u8g2_font_profont11_tf);
 #else
-        displayBrewtime(48, 25, lastBrewTime);
+        displayBrewtimeFs(48, 25, currBrewTime);
 #endif
-
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
         return true;
     }
+
+    return false;
+}
+
+/**
+ * @brief display fullscreen manual flush timer
+ */
+bool displayFullscreenManualFlushTimer() {
+    if (featureFullscreenManualFlushTimer == 0) {
+        return false;
+    }
+
+    if (machineState == kManualFlush) {
+        u8g2.clearBuffer();
+        u8g2.drawXBMP(0, 12, Manual_Flush_Logo_width, Manual_Flush_Logo_height, Manual_Flush_Logo);
+        displayBrewtimeFs(48, 25, currBrewTime);
+        displayWaterIcon(119, 1);
+        u8g2.sendBuffer();
+        return true;
+    }
+
     return false;
 }
 
@@ -302,7 +390,7 @@ bool displayShottimer() {
  */
 bool displayMachineState() {
     // Show the heating logo when we are in regular PID mode and more than 5degC below the set point
-    if (FEATURE_HEATINGLOGO > 0 && machineState == kPidNormal && (setpoint - temperature) > 5. && brewSwitchState != kBrewSwitchFlushOff) {
+    if (featureHeatingLogo > 0 && (machineState == kPidNormal || machineState == kSteam) && (setpoint - temperature) > 5.) {
         // For status info
         u8g2.clearBuffer();
 
@@ -318,7 +406,7 @@ bool displayMachineState() {
         return true;
     }
     // Offline logo
-    else if (FEATURE_PIDOFF_LOGO == 1 && machineState == kPidDisabled) {
+    else if (featurePidOffLogo == 1 && machineState == kPidDisabled) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(38, 0, Off_Logo_width, Off_Logo_height, Off_Logo);
         u8g2.setCursor(0, 55);
@@ -328,7 +416,7 @@ bool displayMachineState() {
         u8g2.sendBuffer();
         return true;
     }
-    else if (FEATURE_PIDOFF_LOGO == 1 && machineState == kStandby) {
+    else if (featurePidOffLogo == 1 && machineState == kStandby) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(38, 0, Off_Logo_width, Off_Logo_height, Off_Logo);
         u8g2.setCursor(36, 55);
@@ -339,7 +427,7 @@ bool displayMachineState() {
         return true;
     }
     // Steam
-    else if (machineState == kSteam && brewSwitchState != kBrewSwitchFlushOff) {
+    else if (machineState == kSteam) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(-1, 12, Steam_Logo_width, Steam_Logo_height, Steam_Logo);
 
@@ -350,7 +438,7 @@ bool displayMachineState() {
         return true;
     }
     // Water empty
-    else if (machineState == kWaterTankEmpty && brewSwitchState != kBrewSwitchFlushOff) {
+    else if (machineState == kWaterTankEmpty) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(45, 0, Water_Tank_Empty_Logo_width, Water_Tank_Empty_Logo_height, Water_Tank_Empty_Logo);
         u8g2.setFont(u8g2_font_profont11_tf);
@@ -364,8 +452,8 @@ bool displayMachineState() {
         u8g2.setCursor(2, 10);
         u8g2.print("Backflush");
 
-        switch (backflushState) {
-            case kBackflushWaitBrewswitchOn:
+        switch (currBackflushState) {
+            case kBackflushIdle:
                 u8g2.setFont(u8g2_font_profont12_tf);
                 u8g2.setCursor(4, 37);
                 u8g2.print(langstring_backflush_press);
@@ -373,7 +461,7 @@ bool displayMachineState() {
                 u8g2.print(langstring_backflush_start);
                 break;
 
-            case kBackflushWaitBrewswitchOff:
+            case kBackflushFinished:
                 u8g2.setFont(u8g2_font_profont12_tf);
                 u8g2.setCursor(4, 37);
                 u8g2.print(langstring_backflush_press);
@@ -384,7 +472,7 @@ bool displayMachineState() {
             default:
                 u8g2.setFont(u8g2_font_fub17_tf);
                 u8g2.setCursor(42, 42);
-                u8g2.print(currBackflushCycles + 1, 0);
+                u8g2.print(currBackflushCycles, 0);
                 u8g2.print("/");
                 u8g2.print(backflushCycles, 0);
                 break;

--- a/src/display/displayRotateUpright.h
+++ b/src/display/displayRotateUpright.h
@@ -87,32 +87,23 @@ void displayEmergencyStop(void) {
 /**
  * @brief display shot timer
  */
+#if (FEATURE_BREWSWITCH == 1)
 bool displayShottimer() {
-    if (((timeBrewed > 0 && FEATURE_BREWCONTROL == 0) || (FEATURE_BREWCONTROL > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished)) && FEATURE_SHOTTIMER == 1) {
-        u8g2.clearBuffer();
 
-        // draw temp icon
-        u8g2.drawXBMP(0, 0, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
-        u8g2.setFont(u8g2_font_profont22_tf);
-        u8g2.setCursor(5, 70);
-        u8g2.print(timeBrewed / 1000, 1);
-        u8g2.setFont(u8g2_font_profont11_tf);
-        u8g2.sendBuffer();
-        return true;
-    }
-    else if (FEATURE_SHOTTIMER == 1 && millis() >= lastBrewTimeMillis && // directly after creating lastbrewTimeMillis (happens when turning off the brew switch, case 43 in the code) should be started
-             lastBrewTimeMillis + SHOTTIMERDISPLAYDELAY >= millis() &&   // should run until millis() has caught up with SHOTTIMERDISPLAYDELAY, this can be used to control the display duration
-             lastBrewTimeMillis < totalBrewTime) // if the totalBrewTime is reached automatically, nothing should be done, otherwise wrong time will be displayed because switch is pressed later than totalBrewTime
-    {
-        u8g2.clearBuffer();
-        u8g2.drawXBMP(0, 0, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
-        u8g2.setFont(u8g2_font_profont22_tf);
-        u8g2.setCursor(5, 70);
-        u8g2.print((lastBrewTimeMillis - startingTime) / 1000, 1);
-        u8g2.setFont(u8g2_font_profont11_tf);
-        u8g2.sendBuffer();
-        return true;
-    }
+    if (featureBrewControl) {
+        // Shown brew time
+        if (shouldDisplayBrewTimer()) {
+            u8g2.clearBuffer();
 
+            u8g2.drawXBMP(0, 0, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
+            u8g2.setFont(u8g2_font_profont22_tf);
+            u8g2.setCursor(5, 70);
+            u8g2.print(currBrewTime / 1000, 1);
+            u8g2.setFont(u8g2_font_profont11_tf);
+            u8g2.sendBuffer();
+            return true;
+        }
+    }
     return false;
 }
+#endif

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -14,14 +14,14 @@
  */
 void printScreen() {
 
-    // Show shot timer:
-    if (displayShottimer()) {
+    // Show fullscreen brew timer:
+    if (displayFullscreenBrewTimer()) {
         // Display was updated, end here
         return;
     }
 
-    // Print the machine state
-    if (displayMachineState()) {
+    // Show fullscreen manual flush timer:
+    if (displayFullscreenManualFlushTimer()) {
         // Display was updated, end here
         return;
     }
@@ -78,26 +78,37 @@ void printScreen() {
 
     u8g2.setFont(u8g2_font_profont11_tf);
 
-    if (isBrewDetected == 1 && currBrewState == kBrewIdle) {
-        u8g2.setCursor(38, 44);
-        u8g2.print("BD: ");
-        u8g2.print((millis() - timeBrewDetection) / 1000, 1);
-        u8g2.print("/");
-        u8g2.print(brewtimesoftware, 0);
+// Brew time
+#if (FEATURE_BREWSWITCH == 1)
+    if (featureBrewControl) {
+        // Shown brew time
+        if (shouldDisplayBrewTimer()) {
+            u8g2.setCursor(34, 44);
+            u8g2.print(langstring_brew);
+            u8g2.print(currBrewTime / 1000, 0);
+            u8g2.print("/");
+            u8g2.print(totalTargetBrewTime / 1000, 0);
+        }
+
+        // Shown flush time
+        if (machineState == kManualFlush) {
+            u8g2.setDrawColor(0);
+            u8g2.drawBox(34, 44, 100, 15);
+            u8g2.setDrawColor(1);
+            u8g2.setCursor(34, 44);
+            u8g2.print(langstring_manual_flush);
+            u8g2.print(currBrewTime / 1000, 0);
+        }
     }
     else {
-        u8g2.setCursor(34, 44);
-        u8g2.print(langstring_brew);
-        u8g2.print(timeBrewed / 1000, 0);
-        u8g2.print("/");
-
-        if (FEATURE_BREWCONTROL == 0) {
-            u8g2.print(brewtimesoftware, 0);
-        }
-        else {
-            u8g2.print(totalBrewTime / 1000, 0);
+        // Brew Timer with optocoupler
+        if (shouldDisplayBrewTimer()) {
+            u8g2.setCursor(34, 44);
+            u8g2.print(langstring_brew);
+            u8g2.print(currBrewTime / 1000, 0);
         }
     }
+#endif
 
     // Show heater output in %
     displayProgressbar(pidOutput / 10, 15, 60, 100);

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -13,8 +13,14 @@
  */
 void printScreen() {
 
-    // Show shot timer:
-    if (displayShottimer()) {
+    // Show fullscreen brew timer:
+    if (displayFullscreenBrewTimer()) {
+        // Display was updated, end here
+        return;
+    }
+
+    // Show fullscreen manual flush timer:
+    if (displayFullscreenManualFlushTimer()) {
         // Display was updated, end here
         return;
     }
@@ -42,62 +48,71 @@ void printScreen() {
         drawTemperaturebar(8, 50, 30);
     }
 
+    // Draw current temp and temp setpoint
     u8g2.setFont(u8g2_font_profont11_tf);
 
     u8g2.setCursor(32, 16);
     u8g2.print("T: ");
     u8g2.print(temperature, 1);
-
     u8g2.print("/");
     u8g2.print(setpoint, 1);
+    u8g2.print((char)176);
+    u8g2.print("C");
 
-    u8g2.setCursor(32, 26);
-    u8g2.print("W: ");
+    // Show current weight if scale has no error
+    displayBrewWeight(32, 26, currReadingWeight, -1, scaleFailure);
 
-    if (scaleFailure) {
-        u8g2.print("fault");
+    /**
+     * @brief Shot timer for scale
+     *
+     * If scale has an error show fault on the display otherwise show current reading of the scale
+     * if brew is running show current brew time and current brew weight
+     * if brewControl is enabled and time or weight target is set show targets
+     * if brewControl is enabled show flush time during manualFlush
+     * if FEATURE_PRESSURESENSOR is enabled show current pressure during brew
+     * if brew is finished show brew values for postBrewTimerDuration
+     */
+
+#if (FEATURE_BREWSWITCH == 1)
+
+    if (featureBrewControl) {
+
+        if (shouldDisplayBrewTimer()) {
+            // time
+            displayBrewTime(32, 36, langstring_brew, currBrewTime, totalTargetBrewTime);
+
+            // weight
+            u8g2.setDrawColor(0);
+            u8g2.drawBox(32, 27, 100, 10);
+            u8g2.setDrawColor(1);
+            displayBrewWeight(32, 26, currBrewWeight, targetBrewWeight, scaleFailure);
+        }
+        // Shown flush time while machine is flushing
+        if (machineState == kManualFlush) {
+            u8g2.setDrawColor(0);
+            u8g2.drawBox(32, 37, 100, 10);
+            u8g2.setDrawColor(1);
+            displayBrewTime(32, 36, langstring_manual_flush, currBrewTime);
+        }
     }
     else {
-        if (machineState == kBrew) {
-            u8g2.print(weightBrew, 0);
-        }
-        else {
-            u8g2.print(weight, 0);
-        }
+        // Brew Timer with optocoupler
+        if (shouldDisplayBrewTimer()) {
+            // time
+            displayBrewTime(32, 36, langstring_brew, currBrewTime);
 
-        if (weightSetpoint > 0) {
-            u8g2.print("/");
-            u8g2.print(weightSetpoint, 0);
+            // weight
+            u8g2.setDrawColor(0);
+            u8g2.drawBox(32, 27, 100, 10);
+            u8g2.setDrawColor(1);
+            displayBrewWeight(32, 26, currBrewWeight, -1, scaleFailure);
         }
-
-        u8g2.print(" (");
-        u8g2.print(weightBrew, 1);
-        u8g2.print(")");
     }
-
-    // Brew
-    u8g2.setCursor(32, 36);
-    u8g2.print("t: ");
-    u8g2.print(timeBrewed / 1000, 0);
-
-    if (FEATURE_BREWCONTROL == 0) {
-        u8g2.print("/");
-        u8g2.print(brewtimesoftware, 0);
-    }
-    else {
-        if (brewTime > 0) {
-            u8g2.print("/");
-            u8g2.print(totalBrewTime / 1000, 0);
-        }
-
-        u8g2.print(" (");
-        u8g2.print(lastBrewTime / 1000, 1);
-        u8g2.print(")");
-    }
+#endif
 
 #if (FEATURE_PRESSURESENSOR == 1)
     u8g2.setCursor(32, 46);
-    u8g2.print("P: ");
+    u8g2.print(langstring_pressure);
     u8g2.print(inputPressure, 1);
 #endif
 

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -13,8 +13,14 @@
  */
 void printScreen() {
 
-    // Show shot timer:
-    if (displayShottimer()) {
+    // Show fullscreen brew timer:
+    if (displayFullscreenBrewTimer()) {
+        // Display was updated, end here
+        return;
+    }
+
+    // Show fullscreen manual flush timer:
+    if (displayFullscreenManualFlushTimer()) {
         // Display was updated, end here
         return;
     }
@@ -32,18 +38,18 @@ void printScreen() {
 
     displayStatusbar();
 
-    u8g2.setCursor(35, 16);
+    u8g2.setCursor(34, 16);
     u8g2.print(langstring_current_temp);
     u8g2.setCursor(84, 16);
     u8g2.print(temperature, 1);
-    u8g2.setCursor(114, 16);
+    u8g2.setCursor(115, 16);
     u8g2.print((char)176);
     u8g2.print("C");
-    u8g2.setCursor(35, 26);
+    u8g2.setCursor(34, 26);
     u8g2.print(langstring_set_temp);
     u8g2.setCursor(84, 26);
     u8g2.print(setpoint, 1);
-    u8g2.setCursor(114, 26);
+    u8g2.setCursor(115, 26);
     u8g2.print((char)176);
     u8g2.print("C");
 
@@ -59,23 +65,29 @@ void printScreen() {
         drawTemperaturebar(8, 50, 30);
     }
 
-    // Brew time
-    u8g2.setCursor(35, 36);
+// Brew and flush time
+#if (FEATURE_BREWSWITCH == 1)
 
-    // Shot timer shown if machine is brewing and after the brew
-    if (machineState == kBrew || machineState == kShotTimerAfterBrew) {
-        u8g2.print(langstring_brew);
-        u8g2.setCursor(84, 36);
-        u8g2.print(timeBrewed / 1000, 0);
-        u8g2.print("/");
-
-        if (FEATURE_BREWCONTROL == 0) {
-            u8g2.print(brewtimesoftware, 0);
+    if (featureBrewControl) {
+        // Shown brew time
+        if (shouldDisplayBrewTimer()) {
+            displayBrewTime(34, 36, langstring_brew, currBrewTime, totalTargetBrewTime);
         }
-        else {
-            u8g2.print(totalBrewTime / 1000, 1);
+        // Shown flush time while machine is flushing
+        if (machineState == kManualFlush) {
+            u8g2.setDrawColor(0);
+            u8g2.drawBox(34, 37, 100, 10);
+            u8g2.setDrawColor(1);
+            displayBrewTime(34, 36, langstring_manual_flush, currBrewTime);
         }
     }
+    else {
+        // Brew Timer with optocoupler
+        if (shouldDisplayBrewTimer()) {
+            displayBrewTime(34, 36, langstring_brew, currBrewTime);
+        }
+    }
+#endif
 
     // PID values over heat bar
     u8g2.setCursor(38, 47);

--- a/src/display/displayTemplateTempOnly.h
+++ b/src/display/displayTemplateTempOnly.h
@@ -18,8 +18,14 @@ float blinkingtempoffset = 0.3; // offset for blinking
  */
 void printScreen() {
 
-    // Show shot timer:
-    if (displayShottimer()) {
+    // Show fullscreen brew timer:
+    if (displayFullscreenBrewTimer()) {
+        // Display was updated, end here
+        return;
+    }
+
+    // Show fullscreen manual flush timer:
+    if (displayFullscreenManualFlushTimer()) {
         // Display was updated, end here
         return;
     }

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -11,17 +11,22 @@
  * @brief Send data to display
  */
 void printScreen() {
-    // Show shot timer:
-    if (displayShottimer()) {
+
+    // Show fullscreen brew timer:
+    if (displayFullscreenBrewTimer()) {
+        // Display was updated, end here
+        return;
+    }
+
+    // Show fullscreen manual flush timer:
+    if (displayFullscreenManualFlushTimer()) {
         // Display was updated, end here
         return;
     }
 
     // If no specific machine state was printed, print default:
 
-    if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) ||
-         ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
-            (brewSwitchState != kBrewSwitchFlushOff) ||
+    if ((machineState == kPidNormal || (machineState == kBrew && FEATURE_SHOTTIMER == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) && (brewSwitchState != kManualFlush) ||
         (machineState == kWaterTankEmpty) || (machineState == kPidDisabled) || (machineState == kStandby) || (machineState == kSteam)) {
         if (!tempSensor->hasError()) {
             u8g2.clearBuffer();
@@ -48,7 +53,7 @@ void printScreen() {
             u8g2.drawLine(1, 126, (pidOutput / 16.13) + 1, 126);
 
             // Show the heating logo when we are in regular PID mode
-            if (FEATURE_HEATINGLOGO > 0 && machineState == kPidNormal && (setpoint - temperature) > 0.3 && brewSwitchState != kBrewSwitchFlushOff) {
+            if (FEATURE_HEATINGLOGO > 0 && machineState == kPidNormal && (setpoint - temperature) > 0.3) {
                 // For status info
 
                 u8g2.drawXBMP(12, 50, Heating_Logo_width, Heating_Logo_height, Heating_Logo);
@@ -72,12 +77,12 @@ void printScreen() {
                 u8g2.print("Standby mode");
             }
             // Steam
-            else if (machineState == kSteam && brewSwitchState != kBrewSwitchFlushOff) {
+            else if (machineState == kSteam) {
 
                 u8g2.drawXBMP(12, 50, Steam_Logo_width, Steam_Logo_height, Steam_Logo);
             }
             // Water empty
-            else if (machineState == kWaterEmpty && brewSwitchState != kBrewSwitchFlushOff) {
+            else if (machineState == kWaterEmpty) {
                 u8g2.drawXBMP(8, 50, Water_Empty_Logo_width, Water_Empty_Logo_height, Water_Empty_Logo);
             }
             else {
@@ -96,98 +101,110 @@ void printScreen() {
                 }
 
                 u8g2.setFont(u8g2_font_profont11_tf);
+            }
 
-                if (isBrewDetected == 1) {
-                    u8g2.setCursor(1, 75);
-                    u8g2.print("BD ");
-                    u8g2.print((millis() - timeBrewDetection) / 1000, 1);
-                    u8g2.print("/");
-                    u8g2.print(brewtimesoftware, 0);
-                }
+            // PID values above heater output bar
+            u8g2.setCursor(1, 84);
+            u8g2.print("P: ");
+            u8g2.print(bPID.GetKp(), 0);
 
-                // PID values above heater output bar
-                u8g2.setCursor(1, 84);
-                u8g2.print("P: ");
-                u8g2.print(bPID.GetKp(), 0);
+            u8g2.setCursor(1, 93);
+            u8g2.print("I: ");
 
-                u8g2.setCursor(1, 93);
-                u8g2.print("I: ");
+            if (bPID.GetKi() != 0) {
+                u8g2.print(bPID.GetKp() / bPID.GetKi(), 0);
+            }
+            else {
+                u8g2.print("0");
+            }
 
-                if (bPID.GetKi() != 0) {
-                    u8g2.print(bPID.GetKp() / bPID.GetKi(), 0);
-                }
-                else {
-                    u8g2.print("0");
-                }
+            u8g2.setCursor(1, 102);
+            u8g2.print("D: ");
+            u8g2.print(bPID.GetKd() / bPID.GetKp(), 0);
 
-                u8g2.setCursor(1, 102);
-                u8g2.print("D: ");
-                u8g2.print(bPID.GetKd() / bPID.GetKp(), 0);
+            u8g2.setCursor(1, 111);
 
-                u8g2.setCursor(1, 111);
+            if (pidOutput < 99) {
+                u8g2.print(pidOutput / 10, 1);
+            }
+            else {
+                u8g2.print(pidOutput / 10, 0);
+            }
 
-                if (pidOutput < 99) {
-                    u8g2.print(pidOutput / 10, 1);
-                }
-                else {
-                    u8g2.print(pidOutput / 10, 0);
-                }
+            u8g2.print("%");
 
-                u8g2.print("%");
+            // Brew
+            u8g2.setCursor(1, 34);
+            u8g2.print(langstring_brew_rot_ur);
+            u8g2.print(currBrewTime / 1000, 0);
 
-                // Brew
+            if (FEATURE_BREWCONTROL == 1) {
+                u8g2.print("/");
+                u8g2.print(totalTargetBrewTime / 1000, 0);
+            }
+
+            u8g2.print(" s");
+        }
+
+        // Brew time
+#if (FEATURE_BREWSWITCH == 1)
+        if (featureBrewControl) {
+            // Show brew time
+            if (shouldDisplayBrewTimer()) {
                 u8g2.setCursor(1, 34);
                 u8g2.print(langstring_brew_rot_ur);
-                u8g2.print(timeBrewed / 1000, 0);
+                u8g2.print(currBrewTime / 1000, 0);
                 u8g2.print("/");
-
-                if (FEATURE_BREWCONTROL == 0) {
-                    u8g2.print(brewtimesoftware, 0);     // deaktivieren wenn Preinfusion ( // voransetzen )
-                }
-                else {
-                    u8g2.print(totalBrewTime / 1000, 0); // aktivieren wenn Preinfusion
-                }
-
+                u8g2.print(totalTargetBrewTime / 1000, 0);
                 u8g2.print(" s");
             }
-            // For status info
-            u8g2.drawFrame(0, 0, 64, 12);
 
-            if (offlineMode == 0) {
-                getSignalStrength();
+            // Shown flush time
+            if (machineState == kManualFlush) {
+                u8g2.setDrawColor(0);
+                u8g2.drawBox(1, 34, 100, 15);
+                u8g2.setDrawColor(1);
+                u8g2.setCursor(1, 34);
+                u8g2.print(langstring_manual_flush_rot_ur);
+                u8g2.print(currBrewTime / 1000, 0);
+                u8g2.print(" s");
+            }
+        }
+        else {
+            // Show brew time with optocoupler
+            if (shouldDisplayBrewTimer()) {
+                u8g2.setCursor(1, 34);
+                u8g2.print(langstring_brew_rot_ur);
+                u8g2.print(currBrewTime / 1000, 0);
+                u8g2.print(" s");
+            }
+        }
+#endif
 
-                if (WiFi.status() == WL_CONNECTED) {
-                    u8g2.drawXBMP(4, 2, 8, 8, Antenna_OK_Icon);
+        // For status info
+        u8g2.drawFrame(0, 0, 64, 12);
 
-                    for (int b = 0; b <= getSignalStrength(); b++) {
-                        u8g2.drawVLine(13 + (b * 2), 10 - (b * 2), b * 2);
-                    }
-                }
-                else {
-                    u8g2.drawXBMP(4, 2, 8, 8, Antenna_NOK_Icon);
-                    u8g2.setCursor(56, 2);
-                    u8g2.print("RC: ");
-                    u8g2.print(wifiReconnects);
-                }
+        if (offlineMode == 0) {
+            getSignalStrength();
 
-                if (FEATURE_MQTT == 1) {
-                    if (mqtt.connected() == 1) {
-                        u8g2.setCursor(24, 2);
-                        u8g2.setFont(u8g2_font_profont11_tf);
-                        u8g2.print("MQTT");
-                    }
-                    else {
-                        u8g2.setCursor(24, 2);
-                        u8g2.print("");
-                    }
+            if (WiFi.status() == WL_CONNECTED) {
+                u8g2.drawXBMP(4, 2, 8, 8, Antenna_OK_Icon);
+
+                for (int b = 0; b <= getSignalStrength(); b++) {
+                    u8g2.drawVLine(13 + (b * 2), 10 - (b * 2), b * 2);
                 }
             }
             else {
-                u8g2.setCursor(4, 1);
-                u8g2.print("Offline");
+                u8g2.setCursor(24, 2);
+                u8g2.print("");
             }
-
-            u8g2.sendBuffer();
         }
     }
+    else {
+        u8g2.setCursor(4, 1);
+        u8g2.print("Offline");
+    }
+
+    u8g2.sendBuffer();
+}
 }

--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -58,7 +58,7 @@ void serverSetup();
 void setEepromWriteFcn(int (*fcnPtr)(void));
 
 // editable vars are specified in main.cpp
-#define EDITABLE_VARS_LEN 35
+#define EDITABLE_VARS_LEN 40
 extern std::map<String, editable_t> editableVars;
 
 // EEPROM

--- a/src/languages.h
+++ b/src/languages.h
@@ -12,25 +12,25 @@
 #if (DISPLAYTEMPLATE <= 4)
 static const char* langstring_set_temp = "Soll:  ";
 static const char* langstring_current_temp = "Ist:   ";
-static const char* langstring_brew = "Brew: ";
+static const char* langstring_brew = "Bezug: ";
+static const char* langstring_weight = "Gewicht: ";
+static const char* langstring_manual_flush = "Spuelen: ";
+static const char* langstring_pressure = "Druck: ";
 static const char* langstring_uptime = "Uptime:  ";
 #endif
 #if (DISPLAYTEMPLATE >= 20) // vertical templates
 static const char* langstring_set_temp_rot_ur = "S: ";
 static const char* langstring_current_temp_rot_ur = "I: ";
 static const char* langstring_brew_rot_ur = "B: ";
+static const char* langstring_manual_flush_rot_ur = "S: ";
 #endif
 
 static const char* langstring_offlinemode = "Offline";
-#if TOF == 1
-static const char* langstring_waterempty = "Wasser leer";
-#endif
-
 static const char* langstring_wifirecon = "Wifi reconnect:";
 static const char* langstring_connectwifi1 = "1: Verbinde WLAN:";
 static const char* langstring_nowifi[] = {"Kein ", "WLAN"};
-
 static const char* langstring_error_tsensor[] = {"Fehler, Temp: ", "Temp.-Sensor ueberpruefen!"};
+static const char* langstring_scale_Failure = "Fehler";
 // static const char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
 
 static const char* langstring_backflush_press = "Bruehsch. druecken";
@@ -42,24 +42,25 @@ static const char* langstring_backflush_finish = "um zu beenden...";
 static const char* langstring_set_temp = "Set:   ";
 static const char* langstring_current_temp = "Temp:  ";
 static const char* langstring_brew = "Brew: ";
+static const char* langstring_weight = "Weight: ";
+static const char* langstring_manual_flush = "Flush: ";
+static const char* langstring_pressure = "Pressure: ";
 static const char* langstring_uptime = "Uptime:  ";
 #endif
 #if (DISPLAYTEMPLATE >= 20) // vertical templates
 static const char* langstring_set_temp_rot_ur = "S: ";
 static const char* langstring_current_temp_rot_ur = "T: ";
 static const char* langstring_brew_rot_ur = "B: ";
+static const char* langstring_manual_flush_rot_ur = "F: ";
 #endif
 
 static const char* langstring_offlinemode = "Offline";
-#if TOF == 1
-static const char* langstring_waterempty = "Empty water";
-#endif
-
 static const char* langstring_wifirecon = "Wifi reconnect:";
 static const char* langstring_connectwifi1 = "1: Connecting Wifi:";
 static const char* langstring_nowifi[] = {"No ", "WIFI"};
 
 static const char* langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. sensor!"};
+static const char* langstring_scale_Failure = "Fault";
 // static const char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
 
 static const char* langstring_backflush_press = "Press brew switch";
@@ -71,24 +72,25 @@ static const char* langstring_backflush_finish = "to finish...";
 static const char* langstring_set_temp = "Obj:  ";
 static const char* langstring_current_temp = "T:    ";
 static const char* langstring_brew = "Brew: ";
+static const char* langstring_weight = "Peso: ";
+static const char* langstring_manual_flush = "Fregar: ";
+static const char* langstring_pressure = "Presión: ";
 static const char* langstring_uptime = "Uptime:  ";
 #endif
 #if (DISPLAYTEMPLATE >= 20) // vertical templates
 static const char* langstring_set_temp_rot_ur = "O: ";
 static const char* langstring_current_temp_rot_ur = "T: ";
 static const char* langstring_brew_rot_ur = "B: ";
+static const char* langstring_manual_flush_rot_ur = "F: ";
 #endif
 
 static const char* langstring_offlinemode = "Offline";
-#if TOF == 1
-static const char* langstring_waterempty = "Agua vacía";
-#endif
-
 static const char* langstring_wifirecon = "Reconecta wifi:";
 static const char* langstring_connectwifi1 = "1: Wifi conectado :";
 static const char* langstring_nowifi[] = {"No ", "WIFI"};
 
 static const char* langstring_error_tsensor[] = {"Error, Temp: ", "Comprueba sensor T!"};
+static const char* langstring_scale_Failure = "falla";
 // static const char *langstring_emergencyStop[] = {"CALENT.", "PARADO "};
 
 static const char* langstring_backflush_press = "Pulsa boton de cafe";

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -39,31 +39,6 @@ struct DiscoveryObject {
 };
 
 /**
- * @brief Get the string name corresponding to a MACHINE enum value.
- *
- * @param machine The MACHINE enum value.
- * @return String The string name of the MACHINE.
- */
-String getMachineName(MACHINE machine) {
-    switch (machine) {
-        case RancilioSilvia:
-            return "RancilioSilvia";
-
-        case RancilioSilviaE:
-            return "RancilioSilviaE";
-
-        case Gaggia:
-            return "Gaggia";
-
-        case QuickMill:
-            return "QuickMill";
-
-        default:
-            return ""; // Handle any unknown or invalid values
-    }
-}
-
-/**
  * @brief Check if MQTT is connected, if not reconnect. Abort function if offline or brew is running
  *      MQTT is also using maxWifiReconnects!
  */
@@ -155,19 +130,24 @@ void assignMQTTParam(char* param, double value) {
                     break;
 
                 case kFloat:
-                    *(float*)var->ptr = value;
-                    mqtt_publish(param, number2string(value), true);
+                    *(float*)var->ptr = static_cast<float>(value);
+                    mqtt_publish(param, number2string(static_cast<float>(value)), true);
                     break;
 
                 case kUInt8:
-                    *(uint8_t*)var->ptr = value;
+                    *(uint8_t*)var->ptr = static_cast<uint8_t>(value);
 
                     if (strcasecmp(param, "steamON") == 0) {
                         steamFirstON = value;
                     }
 
-                    mqtt_publish(param, number2string(value), true);
+                    mqtt_publish(param, number2string(static_cast<uint8_t>(value)), true);
                     writeSysParamsToStorage();
+                    break;
+
+                case kInteger:
+                    *(int*)var->ptr = static_cast<int>(value);
+                    mqtt_publish(param, number2string(static_cast<int>(value)), true);
                     break;
 
                 default:
@@ -176,10 +156,10 @@ void assignMQTTParam(char* param, double value) {
             }
         }
         else {
-            LOGF(WARNING, "Value out of range for MQTT parameter %s", param);
+            LOGF(WARNING, "%s is not a valid MQTT parameter.", param);
         }
     } catch (const std::out_of_range& e) {
-        LOGF(WARNING, "%s is not a valid MQTT parameter.", param);
+        LOGF(WARNING, "Value out of range for MQTT parameter %s", param);
     }
 }
 
@@ -315,7 +295,6 @@ DiscoveryObject GenerateSwitchDevice(String name, String displayName, String pay
     DynamicJsonDocument DeviceMapDoc(1024);
     DeviceMapDoc["identifiers"] = String(hostname);
     DeviceMapDoc["manufacturer"] = "CleverCoffee";
-    DeviceMapDoc["model"] = getMachineName(machine);
     DeviceMapDoc["name"] = String(hostname);
 
     DynamicJsonDocument switchConfigDoc(512);
@@ -367,7 +346,6 @@ DiscoveryObject GenerateButtonDevice(String name, String displayName, String pay
     DynamicJsonDocument DeviceMapDoc(1024);
     DeviceMapDoc["identifiers"] = String(hostname);
     DeviceMapDoc["manufacturer"] = "CleverCoffee";
-    DeviceMapDoc["model"] = getMachineName(machine);
     DeviceMapDoc["name"] = String(hostname);
 
     DynamicJsonDocument buttonConfigDoc(512);
@@ -416,7 +394,6 @@ DiscoveryObject GenerateSensorDevice(String name, String displayName, String uni
     DynamicJsonDocument DeviceMapDoc(1024);
     DeviceMapDoc["identifiers"] = String(hostname);
     DeviceMapDoc["manufacturer"] = "CleverCoffee";
-    DeviceMapDoc["model"] = getMachineName(machine);
     DeviceMapDoc["name"] = String(hostname);
 
     DynamicJsonDocument sensorConfigDoc(512);
@@ -468,7 +445,6 @@ DiscoveryObject GenerateNumberDevice(String name, String displayName, int min_va
     DynamicJsonDocument DeviceMapDoc(1024);
     DeviceMapDoc["identifiers"] = String(hostname);
     DeviceMapDoc["manufacturer"] = "CleverCoffee";
-    DeviceMapDoc["model"] = getMachineName(machine);
     DeviceMapDoc["name"] = String(hostname);
 
     DynamicJsonDocument numberConfigDoc(512);
@@ -504,84 +480,76 @@ DiscoveryObject GenerateNumberDevice(String name, String displayName, int min_va
  * @return 0 if successful, MQTT connection error code if failed to send messages
  */
 int sendHASSIODiscoveryMsg() {
-    // Number Devices
+    // Sensor, number and switch objects which will always be published
+
+    DiscoveryObject machineStateDevice = GenerateSensorDevice("machineState", "Machine State", "", "enum");
+    DiscoveryObject actual_temperature = GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature");
+    DiscoveryObject heaterPower = GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor");
+
     DiscoveryObject brewSetpoint = GenerateNumberDevice("brewSetpoint", "Brew setpoint", BREW_SETPOINT_MIN, BREW_SETPOINT_MAX, 0.1, "°C");
-    DiscoveryObject steamSetPoint = GenerateNumberDevice("steamSetpoint", "Steam setpoint", STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, 0.1, "°C");
+    DiscoveryObject steamSetpoint = GenerateNumberDevice("steamSetpoint", "Steam setpoint", STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, 0.1, "°C");
     DiscoveryObject brewTempOffset = GenerateNumberDevice("brewTempOffset", "Brew Temp. Offset", BREW_TEMP_OFFSET_MIN, BREW_TEMP_OFFSET_MAX, 0.1, "°C");
-    DiscoveryObject brewPidDelay = GenerateNumberDevice("brewPidDelay", "Brew Pid Delay", BREW_PID_DELAY_MIN, BREW_PID_DELAY_MAX, 0.1, "");
-    DiscoveryObject steamKp = GenerateNumberDevice("steamKp", "Start Kp", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, 0.1, "");
+    DiscoveryObject steamKp = GenerateNumberDevice("steamKp", "Steam Kp", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, 0.1, "");
     DiscoveryObject aggKp = GenerateNumberDevice("aggKp", "aggKp", PID_KP_REGULAR_MIN, PID_KP_REGULAR_MAX, 0.1, "");
     DiscoveryObject aggTn = GenerateNumberDevice("aggTn", "aggTn", PID_TN_REGULAR_MIN, PID_TN_REGULAR_MAX, 0.1, "");
     DiscoveryObject aggTv = GenerateNumberDevice("aggTv", "aggTv", PID_TV_REGULAR_MIN, PID_TV_REGULAR_MAX, 0.1, "");
     DiscoveryObject aggIMax = GenerateNumberDevice("aggIMax", "aggIMax", PID_I_MAX_REGULAR_MIN, PID_I_MAX_REGULAR_MAX, 0.1, "");
 
-#if FEATURE_BREWCONTROL == 1
-    DiscoveryObject brewtime = GenerateNumberDevice("brewtime", "Brew time", BREW_TIME_MIN, BREW_TIME_MAX, 0.1, "s");
+    DiscoveryObject pidOn = GenerateSwitchDevice("pidON", "Use PID");
+    DiscoveryObject steamON = GenerateSwitchDevice("steamON", "Steam");
+    DiscoveryObject usePonM = GenerateSwitchDevice("usePonM", "Use PonM");
+
+    // List of all DiscoveryObjects, will be always published
+    std::vector<DiscoveryObject> discoveryObjects = {machineStateDevice, actual_temperature, heaterPower, brewSetpoint, steamSetpoint, brewTempOffset, steamKp, aggKp, aggTn, aggTv, aggIMax, pidOn, steamON, usePonM};
+
+    // Sensor, number and switch object which will be published based on feature set
+#if FEATURE_BREWSWITCH == 1
+
+    DiscoveryObject currBrewTime = GenerateSensorDevice("currBrewTime", "Current Brew Time ", "s", "duration");
+
+    DiscoveryObject brewPidDelay = GenerateNumberDevice("brewPidDelay", "Brew Pid Delay", BREW_PID_DELAY_MIN, BREW_PID_DELAY_MAX, 0.1, "s");
+    DiscoveryObject targetBrewTime = GenerateNumberDevice("targetBrewTime", "Target Brew time", TARGET_BREW_TIME_MIN, TARGET_BREW_TIME_MAX, 0.1, "s");
     DiscoveryObject preinfusion = GenerateNumberDevice("preinfusion", "Preinfusion filling time", PRE_INFUSION_TIME_MIN, PRE_INFUSION_TIME_MAX, 0.1, "s");
     DiscoveryObject preinfusionPause = GenerateNumberDevice("preinfusionPause", "Preinfusion pause time", PRE_INFUSION_PAUSE_MIN, PRE_INFUSION_PAUSE_MAX, 0.1, "s");
     DiscoveryObject backflushCycles = GenerateNumberDevice("backflushCycles", "Backflush Cycles", BACKFLUSH_CYCLES_MIN, BACKFLUSH_CYCLES_MAX, 1, "");
     DiscoveryObject backflushFillTime = GenerateNumberDevice("backflushFillTime", "Backflush filling time", BACKFLUSH_FILL_TIME_MIN, BACKFLUSH_FILL_TIME_MAX, 0.1, "s");
     DiscoveryObject backflushFlushTime = GenerateNumberDevice("backflushFlushTime", "Backflush flushing time", BACKFLUSH_FLUSH_TIME_MIN, BACKFLUSH_FLUSH_TIME_MAX, 0.1, "s");
 
-#endif
-
-    // Sensor Devices
-    DiscoveryObject actual_temperature = GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature");
-    DiscoveryObject heaterPower = GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor");
-    DiscoveryObject machineStateDevice = GenerateSensorDevice("machineState", "Machine State", "", "enum");
-    DiscoveryObject currentWeight = GenerateSensorDevice("currentWeight", "Weight", "g", "weight");
-
-#if FEATURE_PRESSURESENSOR == 1
-    DiscoveryObject pressure = GenerateSensorDevice("pressure", "Pressure", "bar", "pressure");
-#endif
-
-    // Switch Devices
-    DiscoveryObject pidOn = GenerateSwitchDevice("pidON", "Use PID");
-    DiscoveryObject steamON = GenerateSwitchDevice("steamON", "Steam");
-#if FEATURE_BREWCONTROL == 1
     DiscoveryObject backflushOn = GenerateSwitchDevice("backflushOn", "Backflush");
-#endif
-    DiscoveryObject startUsePonM = GenerateSwitchDevice("startUsePonM", "Use PonM");
 
-    // Button Devices
+    discoveryObjects.push_back(currBrewTime);
+    discoveryObjects.push_back(brewPidDelay);
+    discoveryObjects.push_back(targetBrewTime);
+    discoveryObjects.push_back(preinfusion);
+    discoveryObjects.push_back(preinfusionPause);
+    discoveryObjects.push_back(backflushCycles);
+    discoveryObjects.push_back(backflushFillTime);
+    discoveryObjects.push_back(backflushFlushTime);
+    discoveryObjects.push_back(backflushOn);
+#endif
+
+#if FEATURE_SCALE == 1
+
+    DiscoveryObject currReadingWeight = GenerateSensorDevice("currReadingWeight", "Weight", "g", "weight");
+    DiscoveryObject currBrewWeight = GenerateSensorDevice("currBrewWeight", "current Brew Weight", "g", "weight");
+
     DiscoveryObject scaleCalibrateButton = GenerateButtonDevice("scaleCalibrationOn", "Calibrate Scale");
     DiscoveryObject scaleTareButton = GenerateButtonDevice("scaleTareOn", "Tare Scale");
 
-    std::vector<DiscoveryObject> discoveryObjects = {brewSetpoint,
-                                                     steamSetPoint,
-                                                     brewTempOffset,
-                                                     brewPidDelay,
-                                                     steamKp,
-                                                     aggKp,
-                                                     aggTn,
-                                                     aggTv,
-                                                     aggIMax,
-                                                     actual_temperature,
-                                                     heaterPower,
-                                                     machineStateDevice,
-#if FEATURE_BREWCONTROL == 1
-                                                     brewtime,
-                                                     preinfusion,
-                                                     preinfusionPause,
-                                                     backflushOn,
-                                                     backflushCycles,
-                                                     backflushFillTime,
-                                                     backflushFlushTime,
-#endif
-                                                     pidOn,
-                                                     steamON,
-                                                     startUsePonM
+    DiscoveryObject targetBrewWeight = GenerateNumberDevice("targetBrewWeight", "Brew Weight Target", TARGET_BREW_WEIGHT_MIN, TARGET_BREW_WEIGHT_MAX, 0.1, "g");
 
-#if FEATURE_PRESSURESENSOR == 1
-                                                     ,
-                                                     pressure
-#endif
-    };
-
-#if FEATURE_SCALE == 1
-    discoveryObjects.push_back(currentWeight);
+    discoveryObjects.push_back(currReadingWeight);
+    discoveryObjects.push_back(currBrewWeight);
     discoveryObjects.push_back(scaleCalibrateButton);
     discoveryObjects.push_back(scaleTareButton);
+    discoveryObjects.push_back(targetBrewWeight);
+#endif
+
+#if FEATURE_PRESSURESENSOR == 1
+
+    DiscoveryObject pressure = GenerateSensorDevice("pressure", "Pressure", "bar", "pressure");
+
+    discoveryObjects.push_back(pressure);
 #endif
 
     // Send the Objects to Hassio

--- a/src/scaleHandler.h
+++ b/src/scaleHandler.h
@@ -78,9 +78,9 @@ void checkWeight() {
     }
 
 #if SCALE_TYPE == 0
-    weight = w1 + w2;
+    currReadingWeight = w1 + w2;
 #else
-    weight = w1;
+    currReadingWeight = w1;
 #endif
 
     if (scaleCalibrationOn) {
@@ -138,6 +138,7 @@ void initScale() {
 
     if (LoadCell.getTareTimeoutFlag() || LoadCell.getSignalTimeoutFlag()) {
         LOG(ERROR, "Timeout, check MCU>HX711 wiring for scale");
+        u8g2.clearBuffer();
         u8g2.drawStr(0, 32, "failed!");
         u8g2.drawStr(0, 42, "Scale not working..."); // scale timeout will most likely trigger after OTA update, but will still work after boot
         u8g2.sendBuffer();
@@ -149,6 +150,7 @@ void initScale() {
 #if SCALE_TYPE == 0
     if (LoadCell2.getTareTimeoutFlag() || LoadCell2.getSignalTimeoutFlag()) {
         LOG(ERROR, "Timeout, check MCU>HX711 wiring for scale 2");
+        u8g2.clearBuffer();
         u8g2.drawStr(0, 32, "failed!");
         u8g2.drawStr(0, 42, "Scale not working..."); // scale timeout will most likely trigger after OTA update, but will still work after boot
         u8g2.sendBuffer();
@@ -175,28 +177,17 @@ void initScale() {
 void shottimerscale() {
     switch (shottimerCounter) {
         case 10: // waiting step for brew switch turning on
-            if (preinfusionPause == 0 || preinfusion == 0) {
-                if (timeBrewed > 0) {
-                    weightPreBrew = weight;
-                    shottimerCounter = 20;
-                }
-            }
-            else {
-                if (timeBrewed > preinfusion * 1000) {
-                    weightPreBrew = weight;
-                    shottimerCounter = 20;
-                }
-                else if (timeBrewed > 0) {
-                    weightBrew = 0;
-                }
+            if (currBrewState != kBrewIdle) {
+                prewBrewWeight = currReadingWeight;
+                shottimerCounter = 20;
             }
 
             break;
 
         case 20:
-            weightBrew = weight - weightPreBrew;
+            currBrewWeight = currReadingWeight - prewBrewWeight;
 
-            if (timeBrewed == 0) {
+            if (currBrewState == kBrewIdle) {
                 shottimerCounter = 10;
             }
 

--- a/src/steamHandler.h
+++ b/src/steamHandler.h
@@ -20,20 +20,6 @@ void checkSteamSwitch() {
             if (steamSwitchReading == LOW && !steamFirstON) {
                 steamON = 0;
             }
-
-            // monitor QuickMill thermoblock steam-mode
-            if (machine == QuickMill) {
-                if (steamQM_active == true) {
-                    if (checkSteamOffQM() == true) { // if true: steam-mode can be turned off
-                        steamON = 0;
-                        steamQM_active = false;
-                        lastTimeOptocouplerOn = 0;
-                    }
-                    else {
-                        steamON = 1;
-                    }
-                }
-            }
         }
         else if (STEAMSWITCH_TYPE == Switch::MOMENTARY) {
             if (steamSwitchReading != currStateSteamSwitch) {

--- a/src/storage.h
+++ b/src/storage.h
@@ -9,43 +9,45 @@
 
 // storage items
 typedef enum {
-    STO_ITEM_PID_ON,                    // PID on/off state
-    STO_ITEM_PID_USE_PONM,              // Use PonM mode for PID controller (Proportional on Measurement)
-    STO_ITEM_PID_KP_START,              // PID P part at cold start phase
-    STO_ITEM_PID_TN_START,              // PID I part at cold start phase
-    STO_ITEM_PID_KP_REGULAR,            // PID P part at regular operation
-    STO_ITEM_PID_TN_REGULAR,            // PID I part at regular operation
-    STO_ITEM_PID_TV_REGULAR,            // PID D part at regular operation
-    STO_ITEM_PID_I_MAX_REGULAR,         // PID Integrator upper limit
-    STO_ITEM_PID_KP_BD,                 // PID P part at brew detection phase
-    STO_ITEM_PID_TN_BD,                 // PID I part at brew detection phase
-    STO_ITEM_PID_TV_BD,                 // PID D part at brew detection phase
-    STO_ITEM_BREW_SETPOINT,             // brew setpoint
-    STO_ITEM_BREW_TEMP_OFFSET,          // brew temp offset
-    STO_ITEM_USE_BD_PID,                // use separate PID for brew detection (otherwise continue with regular PID)
-    STO_ITEM_BREW_TIME,                 // brew time
-    STO_ITEM_BREW_SW_TIME,              // brew software time
-    STO_ITEM_BREW_PID_DELAY,            // brew PID delay
-    STO_ITEM_BD_THRESHOLD,              // brew detection limit
-    STO_ITEM_WIFI_CREDENTIALS_SAVED,    // flag for wifisetup
-    STO_ITEM_PRE_INFUSION_TIME,         // pre-infusion time
-    STO_ITEM_PRE_INFUSION_PAUSE,        // pre-infusion pause
-    STO_ITEM_PID_KP_STEAM,              // PID P part at steam phase
-    STO_ITEM_STEAM_SETPOINT,            // Setpoint for Steam mode
-    STO_ITEM_SOFT_AP_ENABLED_CHECK,     // soft AP enable state
-    STO_ITEM_WIFI_SSID,                 // Wifi SSID
-    STO_ITEM_WIFI_PASSWORD,             // Wifi password
-    STO_ITEM_WEIGHTSETPOINT,            // Brew weight setpoint
-    STO_ITEM_STANDBY_MODE_ON,           // Enable tandby mode
-    STO_ITEM_STANDBY_MODE_TIME,         // Time until heater is turned off
-    STO_ITEM_SCALE_CALIBRATION_FACTOR,  // Calibration factor for scale
-    STO_ITEM_SCALE2_CALIBRATION_FACTOR, // Calibration factor for scale 2
-    STO_ITEM_SCALE_KNOWN_WEIGHT,        // Calibration weight for scale
-    STO_ITEM_RESERVED_30,               // reserved
-    STO_ITEM_RESERVED_21,               // reserved
-    STO_ITEM_BACKFLUSH_CYCLES,          // number of cycles the backflush should run
-    STO_ITEM_BACKFLUSH_FILL_TIME,       // time in ms the pump is running during backflush
-    STO_ITEM_BACKFLUSH_FLUSH_TIME,      // time in ms the 3-way valve is open during backflush
+    STO_ITEM_PID_ON,                                // PID on/off state
+    STO_ITEM_PID_USE_PONM,                          // Use PonM mode for PID controller (Proportional on Measurement)
+    STO_ITEM_PID_KP_REGULAR,                        // PID P part at regular operation
+    STO_ITEM_PID_TN_REGULAR,                        // PID I part at regular operation
+    STO_ITEM_PID_TV_REGULAR,                        // PID D part at regular operation
+    STO_ITEM_PID_I_MAX_REGULAR,                     // PID Integrator upper limit
+    STO_ITEM_PID_KP_BD,                             // PID P part at brew detection phase
+    STO_ITEM_PID_TN_BD,                             // PID I part at brew detection phase
+    STO_ITEM_PID_TV_BD,                             // PID D part at brew detection phase
+    STO_ITEM_BREW_SETPOINT,                         // brew setpoint
+    STO_ITEM_BREW_TEMP_OFFSET,                      // brew temp offset
+    STO_ITEM_USE_BD_PID,                            // use separate PID for brew detection (otherwise continue with regular PID)
+    STO_ITEM_TARGET_BREW_TIME,                      // target brew time
+    STO_ITEM_BREW_PID_DELAY,                        // brew PID delay
+    STO_ITEM_WIFI_CREDENTIALS_SAVED,                // flag for wifisetup
+    STO_ITEM_PRE_INFUSION_TIME,                     // pre-infusion time
+    STO_ITEM_PRE_INFUSION_PAUSE,                    // pre-infusion pause
+    STO_ITEM_PID_KP_STEAM,                          // PID P part at steam phase
+    STO_ITEM_STEAM_SETPOINT,                        // Setpoint for Steam mode
+    STO_ITEM_SOFT_AP_ENABLED_CHECK,                 // soft AP enable state
+    STO_ITEM_WIFI_SSID,                             // Wifi SSID
+    STO_ITEM_WIFI_PASSWORD,                         // Wifi password
+    STO_ITEM_TARGET_BREW_WEIGHT,                    // Brew weight target
+    STO_ITEM_STANDBY_MODE_ON,                       // Enable tandby mode
+    STO_ITEM_STANDBY_MODE_TIME,                     // Time until heater is turned off
+    STO_ITEM_SCALE_CALIBRATION_FACTOR,              // Calibration factor for scale
+    STO_ITEM_SCALE2_CALIBRATION_FACTOR,             // Calibration factor for scale 2
+    STO_ITEM_SCALE_KNOWN_WEIGHT,                    // Calibration weight for scale
+    STO_ITEM_RESERVED_30,                           // reserved
+    STO_ITEM_RESERVED_21,                           // reserved
+    STO_ITEM_BACKFLUSH_CYCLES,                      // number of cycles the backflush should run
+    STO_ITEM_BACKFLUSH_FILL_TIME,                   // time in ms the pump is running during backflush
+    STO_ITEM_BACKFLUSH_FLUSH_TIME,                  // time in ms the 3-way valve is open during backflush
+    STO_ITEM_FEATURE_BREW_CONTROL,                  // enables function to control pump and solenoid valve
+    STO_ITEM_FEATURE_FULLSCREEN_BREW_TIMER,         // enables full screen brew timer
+    STO_ITEM_FEATURE_FULLSCREEN_MANUAL_FLUSH_TIMER, // enables full screen manual flush timer
+    STO_ITEM_POST_BREW_TIMER_DURATION,              // time in s that brew timer will be shown after brew finished
+    STO_ITEM_FEATURE_HEATING_LOGO,                  // enables full screen logo if mashine is heating
+    STO_ITEM_FEATURE_PID_OFF_LOGO,                  // enables full screen logo if pid is switched off
 
     /* WHEN ADDING NEW ITEMS, THE FOLLOWING HAS TO BE UPDATED:
      * - storage structure:  sto_data_t
@@ -81,7 +83,7 @@ typedef struct __attribute__((packed)) {
         double brewSetpoint;
         double brewTempOffset;
         uint8_t freeToUse3;
-        double brewTimeMs;
+        double targetBrewTimeMs;
         float scaleCalibration;
         double preInfusionTimeMs;
         float scaleKnownWeight;
@@ -94,21 +96,21 @@ typedef struct __attribute__((packed)) {
         uint8_t freeToUse8[2];
         double pidTvBd;
         uint8_t freeToUse9[2];
-        double brewSwTimeSec;
+        double freeToUse10;
         double brewPIDDelaySec;
-        uint8_t freeToUse10;
-        double brewDetectionThreshold;
+        uint8_t freeToUse11;
+        double freeToUse12;
         uint8_t wifiCredentialsSaved;
         uint8_t pidUsePonM;
         double pidKpStart;
-        uint8_t freeToUse12[2];
+        uint8_t freeToUse13[2];
         uint8_t softApEnabledCheck;
-        uint8_t freeToUse13[9];
+        uint8_t freeToUse14[9];
         double pidTnStart;
-        uint8_t freeToUse14[2];
+        uint8_t freeToUse15[2];
         char wifiSSID[25 + 1];
         char wifiPassword[25 + 1];
-        double weightSetpoint;
+        double targetBrewWeight;
         double steamkp;
         double steamSetpoint;
         uint8_t standbyModeOn;
@@ -116,6 +118,12 @@ typedef struct __attribute__((packed)) {
         int backflushCycles;
         double backflushFillTimeMs;
         double backflushFlushTimeMs;
+        uint8_t featureBrewControl;
+        uint8_t featureFullscreenBrewTimer;
+        uint8_t featureFullscreenManualFlushTimer;
+        double postBrewTimerDuration;
+        uint8_t featureHeatingLogo;
+        uint8_t featurePidOffLogo;
 
 } sto_data_t;
 
@@ -132,7 +140,7 @@ static const sto_data_t itemDefaults PROGMEM = {
     SETPOINT,                                                                                                                       // STO_ITEM_BREW_SETPOINT
     TEMPOFFSET,                                                                                                                     // STO_ITEM_BREW_TEMP_OFFSET
     0xFF,                                                                                                                           // free to use
-    BREW_TIME,                                                                                                                      // STO_ITEM_BREW_TIME
+    TARGET_BREW_TIME,                                                                                                               // STO_ITEM_TARGET_BREW_TIME
     SCALE_CALIBRATION_FACTOR,                                                                                                       // STO_ITEM_SCALE_CALIBRATION_FACTOR
     PRE_INFUSION_TIME,                                                                                                              // STO_ITEM_PRE_INFUSION_TIME
     SCALE_KNOWN_WEIGHT,                                                                                                             // STO_ITEM_SCALE_KNOWN_WEIGHT
@@ -145,10 +153,10 @@ static const sto_data_t itemDefaults PROGMEM = {
     {0xFF, 0xFF},                                                                                                                   // free to use
     AGGBTV,                                                                                                                         // STO_ITEM_PID_TV_BD
     {0xFF, 0xFF},                                                                                                                   // free to use
-    BREW_SW_TIME,                                                                                                                   // STO_ITEM_BREW_SW_TIME
+    0xFF,                                                                                                                           // free to use
     BREW_PID_DELAY,                                                                                                                 // STO_ITEM_BREW_PID_DELAY
     0xFF,                                                                                                                           // free to use
-    BD_SENSITIVITY,                                                                                                                 // STO_ITEM_BD_THRESHOLD
+    0xFF,                                                                                                                           // free to use
     WIFI_CREDENTIALS_SAVED,                                                                                                         // STO_ITEM_WIFI_CREDENTIALS_SAVED
     0,                                                                                                                              // STO_ITEM_USE_START_PON_M
     0,                                                                                                                              // free to use
@@ -159,7 +167,7 @@ static const sto_data_t itemDefaults PROGMEM = {
     {0xFF, 0xFF},                                                                                                                   // free to use
     "",                                                                                                                             // STO_ITEM_WIFI_SSID
     "",                                                                                                                             // STO_ITEM_WIFI_PASSWORD
-    SCALE_WEIGHTSETPOINT,                                                                                                           // STO_ITEM_WEIGHTSETPOINT
+    TARGET_BREW_WEIGHT,                                                                                                             // STO_ITEM_TARGET_BREW_WEIGHT
     STEAMKP,                                                                                                                        // STO_ITEM_PID_KP_STEAM
     STEAMSETPOINT,                                                                                                                  // STO_ITEM_STEAM_SETPOINT
     STANDBY_MODE_ON,                                                                                                                // STO_ITEM_STANDBY_MODE_ON
@@ -167,6 +175,12 @@ static const sto_data_t itemDefaults PROGMEM = {
     BACKFLUSH_CYCLES,                                                                                                               // STO_ITEM_BACKFLUSH_CYCLES
     BACKFLUSH_FILL_TIME,                                                                                                            // STO_ITEM_BACKFLUSH_FILLTIME
     BACKFLUSH_FLUSH_TIME,                                                                                                           // STO_ITEM_BACKFLUSH_FLUSHTIME
+    FEATURE_BREW_CONTROL,                                                                                                           // STO_ITEM_FEATURE_BREW_CONTROL
+    FEATURE_FULLSCREEN_BREW_TIMER,                                                                                                  // STO_ITEM_FEATURE_FULLSCREEN_BREW_TIMER
+    FEATURE_FULLSCREEN_MANUAL_FLUSH_TIMER,                                                                                          // STO_ITEM_FEATURE_FULLSCREEN_BREW_TIMER
+    POST_BREW_TIMER_DURATION,                                                                                                       // STO_ITEM_SHOT_TIMER_DISPLAY_DELAY
+    FEATURE_HEATING_LOGO,                                                                                                           // STO_ITEM_FEATURE_HEATING_LOGO
+    FEATURE_PID_OFF_LOGO,                                                                                                           // STO_ITEM_FEATURE_PID_OFF_LOGO
 };
 
 /**
@@ -214,9 +228,9 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
             size = STRUCT_MEMBER_SIZE(sto_data_t, brewTempOffset);
             break;
 
-        case STO_ITEM_BREW_TIME:
-            addr = offsetof(sto_data_t, brewTimeMs);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, brewTimeMs);
+        case STO_ITEM_TARGET_BREW_TIME:
+            addr = offsetof(sto_data_t, targetBrewTimeMs);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, targetBrewTimeMs);
             break;
 
         case STO_ITEM_PRE_INFUSION_TIME:
@@ -254,16 +268,6 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
             size = STRUCT_MEMBER_SIZE(sto_data_t, pidTvBd);
             break;
 
-        case STO_ITEM_BREW_SW_TIME:
-            addr = offsetof(sto_data_t, brewSwTimeSec);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, brewSwTimeSec);
-            break;
-
-        case STO_ITEM_BD_THRESHOLD:
-            addr = offsetof(sto_data_t, brewDetectionThreshold);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, brewDetectionThreshold);
-            break;
-
         case STO_ITEM_WIFI_CREDENTIALS_SAVED:
             addr = offsetof(sto_data_t, wifiCredentialsSaved);
             size = STRUCT_MEMBER_SIZE(sto_data_t, wifiCredentialsSaved);
@@ -272,16 +276,6 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
         case STO_ITEM_PID_USE_PONM:
             addr = offsetof(sto_data_t, pidUsePonM);
             size = STRUCT_MEMBER_SIZE(sto_data_t, pidUsePonM);
-            break;
-
-        case STO_ITEM_PID_KP_START:
-            addr = offsetof(sto_data_t, pidKpStart);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, pidKpStart);
-            break;
-
-        case STO_ITEM_PID_TN_START:
-            addr = offsetof(sto_data_t, pidTnStart);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, pidTnStart);
             break;
 
         case STO_ITEM_SOFT_AP_ENABLED_CHECK:
@@ -309,9 +303,9 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
             size = STRUCT_MEMBER_SIZE(sto_data_t, steamkp);
             break;
 
-        case STO_ITEM_WEIGHTSETPOINT:
-            addr = offsetof(sto_data_t, weightSetpoint);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, weightSetpoint);
+        case STO_ITEM_TARGET_BREW_WEIGHT:
+            addr = offsetof(sto_data_t, targetBrewWeight);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, targetBrewWeight);
             break;
 
         case STO_ITEM_STEAM_SETPOINT:
@@ -357,6 +351,36 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
         case STO_ITEM_BACKFLUSH_FLUSH_TIME:
             addr = offsetof(sto_data_t, backflushFlushTimeMs);
             size = STRUCT_MEMBER_SIZE(sto_data_t, backflushFlushTimeMs);
+            break;
+
+        case STO_ITEM_FEATURE_BREW_CONTROL:
+            addr = offsetof(sto_data_t, featureBrewControl);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, featureBrewControl);
+            break;
+
+        case STO_ITEM_FEATURE_FULLSCREEN_BREW_TIMER:
+            addr = offsetof(sto_data_t, featureFullscreenBrewTimer);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, featureFullscreenBrewTimer);
+            break;
+
+        case STO_ITEM_FEATURE_FULLSCREEN_MANUAL_FLUSH_TIMER:
+            addr = offsetof(sto_data_t, featureFullscreenManualFlushTimer);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, featureFullscreenManualFlushTimer);
+            break;
+
+        case STO_ITEM_POST_BREW_TIMER_DURATION:
+            addr = offsetof(sto_data_t, postBrewTimerDuration);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, postBrewTimerDuration);
+            break;
+
+        case STO_ITEM_FEATURE_HEATING_LOGO:
+            addr = offsetof(sto_data_t, featureHeatingLogo);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, featureHeatingLogo);
+            break;
+
+        case STO_ITEM_FEATURE_PID_OFF_LOGO:
+            addr = offsetof(sto_data_t, featurePidOffLogo);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, featurePidOffLogo);
             break;
 
         default:
@@ -682,7 +706,7 @@ int storageGet(sto_item_id_t itemId, String& itemValue) {
  *        The value is set in the RAM only! Use 'commit=true' or call
  *        storageCommit() to write the RAM content to the non-volatile memory!
  *
- *  @param itemId    - storage item ID
+ * @param itemId    - storage item ID
  * @param itemValue - item value to set
  * @param commit    - true=write current RAM content to NV memory (optional, default=false)
  *

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -13,34 +13,19 @@
 #define USR_FW_HOTFIX     0
 #define USR_FW_BRANCH     "MASTER"
 
-// List of supported machines
-enum MACHINE {
-    RancilioSilvia,  // MACHINEID 0
-    RancilioSilviaE, // MACHINEID 1
-    Gaggia,          // MACHINEID 2
-    QuickMill        // MACHINEID 3
-};
-
 /**
  * Preconfiguration
  */
 
-// Machine
-#define MACHINEID RancilioSilvia // Machine type (see enum MACHINE)
-
 // Display
-#define OLED_DISPLAY          2       // 0 = deactivated, 1 = SH1106 (e.g. 1.3 "128x64), 2 = SSD1306 (e.g. 0.96" 128x64), 3 = SH1106_126x64_SPI
-#define OLED_I2C              0x3C    // I2C address for OLED, 0x3C by default
-#define DISPLAYTEMPLATE       3       // 1 = Standard display template, 2 = Minimal template, 3 = only temperature, 4 = scale template, 20 = vertical display (see git Handbook for further information)
-#define DISPLAYROTATE         U8G2_R0 // rotate display clockwise: U8G2_R0 = no rotation; U8G2_R1 = 90°; U8G2_R2 = 180°; U8G2_R3 = 270°
-#define SCREEN_WIDTH          128     // OLED display width, in pixels
-#define SCREEN_HEIGHT         64      // OLED display height, in pixels
-#define FEATURE_SHOTTIMER     1       // 0 = deactivated, 1 = activated (with weight if FEATURE_SCALE activated)
-#define FEATURE_HEATINGLOGO   1       // 0 = deactivated, 1 = activated
-#define FEATURE_PIDOFF_LOGO   1       // 0 = deactivated, 1 = activated
-#define SHOTTIMERDISPLAYDELAY 3000    // time in ms that shot timer will be shown after brew finished
+#define OLED_DISPLAY    2       // 0 = deactivated, 1 = SH1106 (e.g. 1.3 "128x64), 2 = SSD1306 (e.g. 0.96" 128x64), 3 = SH1106_126x64_SPI
+#define OLED_I2C        0x3C    // I2C address for OLED, 0x3C by default
+#define DISPLAYTEMPLATE 3       // 1 = Standard display template, 2 = Minimal template, 3 = only temperature, 4 = scale template, 20 = vertical display (see git Handbook for further information)
+#define DISPLAYROTATE   U8G2_R0 // rotate display clockwise: U8G2_R0 = no rotation; U8G2_R1 = 90°; U8G2_R2 = 180°; U8G2_R3 = 270°
+#define SCREEN_WIDTH    128     // OLED display width, in pixels
+#define SCREEN_HEIGHT   64      // OLED display height, in pixels
 
-#define LANGUAGE 0                    // LANGUAGE = 0 (DE), LANGUAGE = 1 (EN), LANGUAGE = 2 (ES)
+#define LANGUAGE 0              // LANGUAGE = 0 (DE), LANGUAGE = 1 (EN), LANGUAGE = 2 (ES)
 
 // Connectivity
 #define CONNECTMODE         1              // 0 = offline 1 = WIFI-MODE
@@ -50,9 +35,6 @@ enum MACHINE {
 #define WIFICONNECTIONDELAY 10000          // delay between reconnects in ms
 
 // PID & Hardware
-#define FEATURE_BREWCONTROL     0                       // 0 = deactivated, 1 = activated
-#define FEATURE_BREWDETECTION   1                       // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE      1                       // 1 = Software (FEATURE_BREWCONTROL 0), 2 = Hardware (FEATURE_BREWCONTROL 1), 3 = Optocoupler (FEATURE_BREWCONTROL 0)
 #define FEATURE_POWERSWITCH     0                       // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE        Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE        Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
@@ -61,7 +43,6 @@ enum MACHINE {
 #define BREWSWITCH_MODE         Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
 #define FEATURE_STEAMSWITCH     0                       // 0 = deactivated, 1 = activated
 #define STEAMSWITCH_TYPE        Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
-#define OPTOCOUPLER_TYPE        HIGH                    // BREWDETECTION 3 configuration; HIGH or LOW trigger optocoupler
 #define STEAMSWITCH_MODE        Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
 #define HEATER_SSR_TYPE         Relay::HIGH_TRIGGER     // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER
 #define PUMP_VALVE_SSR_TYPE     Relay::HIGH_TRIGGER     // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER


### PR DESCRIPTION
This PR removed the Brew detection in total
-> SW Brewdetection is gone (wasn´t really accurately)
-> Removed Quickmill/Thermoblock steam mode detection (was broken)
-> Removed kShotTimerAfterBrew and kBrewdetectionTrailing
-> Backflush isn´t possible anymore if mashine is in steam mode

Adding:
Detection for brew works in total over Brewswitch input
Brewswitch Pin could be used for a switch or a optocoupler
removed brewOn from checkbrewswitch() to brew() -> this triggers all brew related stuff (eg kBrew)
new brew timer for "pid+" (optocoupler)
showing brew time and shottimer based on kBrew
postBrewTimerDuration is now directly in the display templates 
manual flush in own function and mashine state
manual flush triggers resetStandbyTime and can end standbyMode
add manual flush to display templates
FEATURE_BREWCONTROL is now set on the website
moved all brew or backflush related stuff into brewHandler.h
moved Display related settings onto website
rework shot timer in scale display template
renamed shot timer, flush timer seperated
show heating logo while steam temperature isn´t reached
new method to decide if brew timer is visible or not
new method to draw brewTimer and flushTimer
new method to draw brewWeight


to discuss:
show sections on website only if needed
add pressure to shot timer?
fix uprightDisplayTemplate