### PR TITLE
Expand StandardLEDs

### DIFF
--- a/src/hardware/LED.h
+++ b/src/hardware/LED.h
@@ -26,6 +26,7 @@ class LED {
         virtual void turnOff() = 0;
         virtual void setColor(int red, int green, int blue) = 0;
         virtual void setBrightness(int value) = 0;
+        virtual void setGPIOState(bool state);
         virtual ~LED() {
         }
 };

--- a/src/hardware/StandardLED.cpp
+++ b/src/hardware/StandardLED.cpp
@@ -7,16 +7,27 @@
 #include "StandardLED.h"
 #include "GPIOPin.h"
 
-StandardLED::StandardLED(GPIOPin& gpioInstance) :
-    gpio(gpioInstance) {
+StandardLED::StandardLED(GPIOPin& gpioInstance, int featureFlag) :
+    gpio(gpioInstance), enabled(featureFlag != 0), inverted(featureFlag == 2) {
+}
+
+void StandardLED::setGPIOState(bool state) {
+    if (enabled) {
+        if (inverted) {
+            gpio.write(state ? LOW : HIGH); // Inverted logic
+        }
+        else {
+            gpio.write(state ? HIGH : LOW); // Normal logic
+        }
+    }
 }
 
 void StandardLED::turnOn() {
-    gpio.write(HIGH);
+    setGPIOState(true); // Turn on
 }
 
 void StandardLED::turnOff() {
-    gpio.write(LOW);
+    setGPIOState(false); // Turn off
 }
 
 void StandardLED::setColor(int red, int green, int blue) {

--- a/src/hardware/StandardLED.h
+++ b/src/hardware/StandardLED.h
@@ -12,13 +12,16 @@ class GPIOPin;
 
 class StandardLED : public LED {
     public:
-        StandardLED(GPIOPin& gpioInstance);
+        StandardLED(GPIOPin& gpioInstance, int featureFlag);
 
         void turnOn() override;
         void turnOff() override;
         void setColor(int red, int green, int blue);
         void setBrightness(int value);
+        void setGPIOState(bool state) override;
 
     private:
         GPIOPin& gpio;
+        bool inverted; // If true, invert on/off behavior
+        bool enabled;  // If false, the LED will be disabled
 };

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -46,8 +46,9 @@
 #define STEAMSWITCH_MODE        Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
 #define HEATER_SSR_TYPE         Relay::HIGH_TRIGGER     // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER
 #define PUMP_VALVE_SSR_TYPE     Relay::HIGH_TRIGGER     // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER
-#define FEATURE_STATUS_LED      0                       // Blink status LED when temp is in range, 0 = deactivated, 1 = activated
-#define FEATURE_BREW_LED        0                       // Turn on brew LED when brew is started, 0 = deactivated, 1 = activated
+#define FEATURE_STATUS_LED      0                       // Blink status LED when temp is in range, 0 = deactivated, 1 = activated, 2 = activated inverted
+#define FEATURE_BREW_LED        0                       // Turn on brew LED when brew is started, 0 = deactivated, 1 = activated, 2 = activated inverted
+#define FEATURE_STEAM_LED       0                       // Turn on steam LED when switch is started, 0 = deactivated, 1 = activated, 2 = activated inverted
 #define LED_TYPE                LED::STANDARD           // STANDARD_LED for an LED connected to a GPIO pin, WS2812 for adressable LEDs
 #define FEATURE_WATERTANKSENSOR 0                       // 0 = deactivated, 1 = activated
 #define WATERTANKSENSOR_TYPE    Switch::NORMALLY_CLOSED // Switch::NORMALLY_CLOSED for sensor XKC-Y25-NPN or Switch::NORMALLY_OPEN for XKC-Y25-PNP


### PR DESCRIPTION
This edit does not require a change in wiring, any installation that was using LEDs before maintain the same functionality.

Modified LEDs to include enable and inversion handling withing StandardLED.
Included Steam LED code to suit existing pin declaration.
Removed all if statements checking if LED is enabled as it is no longer needed.
Added turn off for brew, steam and water after declaration.

Inverting the LED output reduces wiring and is compatible with the switches in the default Switch::NORMALLY_OPEN state, using either Switch::TOGGLE or Switch::MOMENTARY actions.

To wire each switch it consists of 3.3v, switch and LED wires, no ground is necessary. The LED is installed where the original light connected, then it can be controlled independently of the switch state.

The switch connections are 3.3v on the top on the side that LED positive is, the LED wire is on top on LED negative, then switch wire is beneath the 3.3v. The LED wire could also go on the bottom on LED negative but then it will only be able to be controlled when the switch is active.

The LED requires a resistor in line either inside the switch, on the LED wire or on the PCB.