### PR TITLE
Timing optimisations

### DIFF
--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -358,7 +358,7 @@ bool displayFullscreenBrewTimer() {
         displayBrewtimeFs(48, 25, currBrewTime);
 #endif
         displayWaterIcon(119, 1);
-        u8g2.sendBuffer();
+        displayBufferReady = true;
         return true;
     }
 
@@ -378,7 +378,7 @@ bool displayFullscreenManualFlushTimer() {
         u8g2.drawXBMP(0, 12, Manual_Flush_Logo_width, Manual_Flush_Logo_height, Manual_Flush_Logo);
         displayBrewtimeFs(48, 25, currBrewTime);
         displayWaterIcon(119, 1);
-        u8g2.sendBuffer();
+        displayBufferReady = true;
         return true;
     }
 

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -113,5 +113,5 @@ void printScreen() {
     // Show heater output in %
     displayProgressbar(pidOutput / 10, 15, 60, 100);
 
-    u8g2.sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -119,5 +119,5 @@ void printScreen() {
     // Show heater output in %
     displayProgressbar(pidOutput / 10, 30, 60, 98);
 
-    u8g2.sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -118,5 +118,5 @@ void printScreen() {
     // Show heater output in %
     displayProgressbar(pidOutput / 10, 30, 60, 98);
 
-    u8g2.sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/display/displayTemplateTempOnly.h
+++ b/src/display/displayTemplateTempOnly.h
@@ -73,5 +73,5 @@ void printScreen() {
 
     displayStatusbar();
 
-    u8g2.sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/standby.h
+++ b/src/standby.h
@@ -18,41 +18,48 @@ unsigned long timeSinceStandbyMillis = 0;
  * @brief Decrements the remaining standby time every second, counting down from the configured duration
  */
 void updateStandbyTimer(void) {
-    unsigned long currentTime = millis();
+    if (standbyModeOn) {
+        unsigned long currentTime = millis();
 
-    if ((standbyModeRemainingTimeMillis != 0) && ((currentTime % 1000) == 0) && (currentTime != lastStandbyTimeMillis)) {
-        unsigned long standbyModeTimeMillis = standbyModeTime * 60 * 1000;
-        long elapsedTime = currentTime - standbyModeStartTimeMillis;
-        lastStandbyTimeMillis = currentTime;
+        if ((standbyModeRemainingTimeMillis != 0) && ((currentTime % 1000) == 0) && (currentTime != lastStandbyTimeMillis)) {
+            unsigned long standbyModeTimeMillis = standbyModeTime * 60 * 1000;
+            long elapsedTime = currentTime - standbyModeStartTimeMillis;
+            lastStandbyTimeMillis = currentTime;
 
-        if (standbyModeTimeMillis > elapsedTime) {
-            standbyModeRemainingTimeMillis = standbyModeTimeMillis - elapsedTime;
+            if (standbyModeTimeMillis > elapsedTime) {
+                standbyModeRemainingTimeMillis = standbyModeTimeMillis - elapsedTime;
 
-            if ((currentTime % 60000) == 0) {
-                LOGF(INFO, "Standby time remaining: %i minutes", standbyModeRemainingTimeMillis / 60000);
+                if ((currentTime % 60000) == 0) {
+                    LOGF(INFO, "Standby time remaining: %i minutes", standbyModeRemainingTimeMillis / 60000);
+                }
+            }
+            else {
+                standbyModeRemainingTimeMillis = 0;
+                LOG(INFO, "Entering standby mode...");
             }
         }
-        else {
-            standbyModeRemainingTimeMillis = 0;
-            LOG(INFO, "Entering standby mode...");
+        else if ((standbyModeRemainingTimeDisplayOffMillis != 0) && ((currentTime % 1000) == 0) && (currentTime != lastStandbyTimeMillis)) {
+            unsigned long standbyModeTimeMillis = (standbyModeTime * 60 * 1000) + (TIME_TO_DISPLAY_OFF * 60 * 1000);
+            long elapsedTime = currentTime - standbyModeStartTimeMillis;
+            lastStandbyTimeMillis = currentTime;
+
+            if (standbyModeTimeMillis > elapsedTime) {
+                standbyModeRemainingTimeDisplayOffMillis = standbyModeTimeMillis - elapsedTime;
+
+                if ((currentTime % 60000) == 0) {
+                    LOGF(INFO, "Standby time until display is turned off: %i minutes", standbyModeRemainingTimeDisplayOffMillis / 60000);
+                }
+            }
+            else {
+                standbyModeRemainingTimeDisplayOffMillis = 0;
+                LOG(INFO, "Turning off display...");
+            }
         }
     }
-    else if ((standbyModeRemainingTimeDisplayOffMillis != 0) && ((currentTime % 1000) == 0) && (currentTime != lastStandbyTimeMillis)) {
-        unsigned long standbyModeTimeMillis = (standbyModeTime * 60 * 1000) + (TIME_TO_DISPLAY_OFF * 60 * 1000);
-        long elapsedTime = currentTime - standbyModeStartTimeMillis;
-        lastStandbyTimeMillis = currentTime;
-
-        if (standbyModeTimeMillis > elapsedTime) {
-            standbyModeRemainingTimeDisplayOffMillis = standbyModeTimeMillis - elapsedTime;
-
-            if ((currentTime % 60000) == 0) {
-                LOGF(INFO, "Standby time until display is turned off: %i minutes", standbyModeRemainingTimeDisplayOffMillis / 60000);
-            }
-        }
-        else {
-            standbyModeRemainingTimeDisplayOffMillis = 0;
-            LOG(INFO, "Turning off display...");
-        }
+    else {
+        standbyModeRemainingTimeMillis = standbyModeTime * 60 * 1000;
+        standbyModeRemainingTimeDisplayOffMillis = TIME_TO_DISPLAY_OFF * 60 * 1000;
+        standbyModeStartTimeMillis = millis();
     }
 }
 

--- a/src/utils/timingDebug.h
+++ b/src/utils/timingDebug.h
@@ -1,0 +1,108 @@
+/**
+ * @file timingDebug.h
+ *
+ * @brief Stores and prints long duration processes to the console if DEBUG is enabled
+ *
+ */
+
+#pragma once
+
+enum ActivityType : uint16_t {
+    ACT_DISPLAY_READY = 0x01,
+    ACT_DISPLAY_RUNNING = 0x02,
+    ACT_WEBSITE_RUNNING = 0x04,
+    ACT_MQTT_RUNNING = 0x08,
+    ACT_HASSIO_RUNNING = 0x10
+};
+
+/**
+ * @brief print what has caused the long loop time
+ * @return void
+ */
+void printActivityFlags(const uint16_t* activity, int size) {
+    char activityBuffer[512];
+    int len = 0;
+
+    len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "Activity (short): [");
+    for (int i = 0; i < size; ++i) {
+        // Convert flags to short notation
+        if (activity[i] == 0) {
+            len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "_");
+        }
+        else {
+            if (activity[i] & ACT_DISPLAY_READY) len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "r");
+            if (activity[i] & ACT_DISPLAY_RUNNING) len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "D");
+            if (activity[i] & ACT_WEBSITE_RUNNING) len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "W");
+            if (activity[i] & ACT_MQTT_RUNNING) len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "M");
+            if (activity[i] & ACT_HASSIO_RUNNING) len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "H");
+        }
+        if (i < size - 1) len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, ",");
+    }
+    len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "]");
+
+    LOGF(DEBUG, "%s", activityBuffer);
+}
+
+/**
+ * @brief Print both timing and compact activity in one batch
+ * @return void
+ */
+void printTimingAndActivityBatch(const unsigned long* timing, const uint16_t* activity, int size) {
+    char timingBuffer[512];
+    int tLen = 0;
+
+    tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, "Loop timing (ms): [");
+    for (int i = 0; i < size; ++i) {
+        tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, "%lu", timing[i]);
+        if (i < size - 1) tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, ",");
+    }
+    tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, "]");
+
+    // Only two log lines total
+    LOGF(DEBUG, "%s", timingBuffer);
+    printActivityFlags(activity, size);
+}
+
+/**
+ * @brief Store all long duration activities and their loop times, send when array is full
+ * @return void
+ */
+void debugTimingLoop() {
+    static const int LOOP_HISTORY_SIZE = 20;
+    static unsigned long loopTiming[LOOP_HISTORY_SIZE];
+    static uint16_t activityType[LOOP_HISTORY_SIZE];
+    static unsigned long previousMillisDebug = millis();
+    static unsigned long lastSendMillisDebug = millis();
+    static unsigned int loopIndex = 0;
+    static unsigned int loopCount = 0;
+    static unsigned long maxLoop = 0;
+
+    IFLOG(DEBUG) {
+        loopCount += 1;
+        unsigned long loopDuration = millis() - previousMillisDebug;
+        previousMillisDebug = millis();
+        if ((loopDuration > 35) || (displayUpdateRunning || websiteUpdateRunning || mqttUpdateRunning || hassioUpdateRunning)) {
+            if (loopDuration >= maxLoop) {
+                maxLoop = loopDuration;
+            }
+            loopTiming[loopIndex] = loopDuration;
+            activityType[loopIndex] = 0;
+            if (displayBufferReady) activityType[loopIndex] |= ACT_DISPLAY_READY;
+            if (displayUpdateRunning) activityType[loopIndex] |= ACT_DISPLAY_RUNNING;
+            if (websiteUpdateRunning) activityType[loopIndex] |= ACT_WEBSITE_RUNNING;
+            if (mqttUpdateRunning) activityType[loopIndex] |= ACT_MQTT_RUNNING;
+            if (hassioUpdateRunning) activityType[loopIndex] |= ACT_HASSIO_RUNNING;
+
+            loopIndex = (loopIndex + 1) % LOOP_HISTORY_SIZE;
+            if (loopIndex == 0) {
+                printTimingAndActivityBatch(loopTiming, activityType, LOOP_HISTORY_SIZE);
+                unsigned long reportTime = millis() - lastSendMillisDebug;
+                float avgLoopMs = loopCount > 0 ? ((float)reportTime / loopCount) : 0;
+                LOGF(DEBUG, "Max time %lu (ms) -- %i entries report time %lu (ms) -- average %0.2f (ms)", maxLoop, LOOP_HISTORY_SIZE, reportTime, avgLoopMs);
+                lastSendMillisDebug = millis();
+                loopCount = 0;
+                maxLoop = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Changes have been made to minimise overlap of long running tasks and reduce excessive MQTT data. There is more that could be done but this only required minor changes instead of major rewrites. The boolean flags that block processes do increase the latency of these tasks by an extra loop, which is typically 0.5ms. Each long running task is given a unique flag, so blocking of other tasks can be selective on which tasks it will run with within the same loop.

Before
regular spikes over 100ms and even up to 2s when HASSIO discovery runs, as all the other processes were running in the same loop after this. These caused stuttery behaviour in the main screen and during brews and also increased the frequency of missed switch inputs.

After
These changes have resulted in the maximum loop time being typically 35ms (display sendBuffer) with very infrequent HASSIO discovery sends outside of critical times.

MQTT
Each time writeSysParamsToMQTT was called it would send around 70 messages for around 35 parameters, taking an average of 100ms each send. By storing the sent values in an array it reduces to only the changed variables, so send time is more like 15-50ms. Reducing the impact of these calls allows high speed refreshes during brews without significant increase to loop timing. The MQTT send interval has been split into Normal, Brew and Standby.

Display
sendBuffer() takes around 35ms to complete, and drawing the display into the buffer can take a few ms depending on its complexity. Changing to a boolean to flag the buffer is ready, then calling sendBuffer() on the next loop reduces the loop time to around 5ms then 35ms next loop, instead of one loop of 40ms. Standby mode with display off was still sending data to the display that was set to ignore it.

HASSIO discovery
Every 5 minutes HASSIO discovery was sent, taking between 200ms and 2s. If this happens during a brew the screen pauses for this time while the discovery message is sent. The retain flag is set so MQTT stores the discovery messages, so constant sending is not required. Limiting the send to only while not in a brew and only after MQTT disconnection reduces these blocking calls.

Website
The website refresh is only a few ms, blocking its update to only when other tasks have not run in the same loop minimises maximum loop time.

Standby
It would go into standby even if not enabled, so a check of standbyModeOn was added and if false then keep resetting the timers similar to resetStandbyTimer(void) but without the log.

Other changes
WeightSetpoint was not included in HASSIO discovery, and Steam Kp had an incorrect name.