### PR TITLE
Changed upright display to work with the new brew method

### DIFF
--- a/src/display/displayRotateUpright.h
+++ b/src/display/displayRotateUpright.h
@@ -42,13 +42,166 @@ void displayMessage(String text1, String text2, String text3, String text4, Stri
 #endif
 
 /**
+ * @brief Draw a water empty icon at the given coordinates if water supply is low
+ */
+void displayWaterIcon(int x, int y) {
+    if (!waterTankFull) {
+        u8g2.drawXBMP(x, y, 8, 8, Water_Tank_Empty_Icon);
+    }
+}
+
+/**
+ * @brief Draw the brew time at given position (fullscreen brewtimer)
+ */
+void displayBrewtimeFs(int x, int y, double brewtime) {
+    u8g2.setFont(u8g2_font_fub20_tf);
+    if (brewtime < 10000.000) {
+        u8g2.setCursor(x + 15, y);
+    }
+    else {
+        u8g2.setCursor(x, y);
+    }
+    u8g2.print(brewtime / 1000, 1);
+    u8g2.setFont(u8g2_font_profont15_tf);
+    u8g2.setCursor(x, y + 25);
+    u8g2.print("seconds");
+    u8g2.setFont(u8g2_font_profont11_tf);
+}
+
+/**
+ * @brief print error message for scales
+ */
+void displayScaleFailed(void) {
+    u8g2.clearBuffer();
+    u8g2.drawStr(0, 32, "Failed!");
+    u8g2.drawStr(0, 42, "Scale");
+    u8g2.drawStr(0, 52, "not");
+    u8g2.drawStr(0, 62, "working...");
+    u8g2.sendBuffer();
+}
+
+/**
+ * @brief Draw current brew time with optional brew target time at given position
+ *
+ * Shows the current brew time in seconds. If a target time (totalTargetBrewTime) is provided (> 0), it is displayed alongside the current time.
+ *
+ * @param x              Horizontal position to start drawing
+ * @param y              Vertical position to start drawing
+ * @param label          Text label to display before the time
+ * @param currBrewTime     Current brewed time in milliseconds
+ * @param totalTargetBrewTime  Target brew time in milliseconds (optional, default -1)
+ */
+void displayBrewTime(int x, int y, const char* label, double currBrewTime, double totalTargetBrewTime = -1) {
+    u8g2.setCursor(x, y);
+    u8g2.print(label);
+    u8g2.print(currBrewTime / 1000, 0);
+
+    if (totalTargetBrewTime > 0) {
+        u8g2.print("/");
+        u8g2.print(totalTargetBrewTime / 1000, 0);
+    }
+    u8g2.print(" s");
+}
+
+/**
+ * @brief Draw the current weight with error handling and target indicators at given position
+ *
+ * If the scale reports an error, "fault" is shown on the display instead of weight.
+ * Otherwise, the function displays the current weight.
+ * If a target weight (setpoint) is set (> 0), it will be displayed alongside the current weight.
+ * This function is intended to provide the status of the scales during brewing, flushing, or other machine states.
+ *
+ * @param x        Horizontal position to start drawing
+ * @param y        Vertical position to start drawing
+ * @param weight   Current measured weight to display
+ * @param setpoint Target weight to display alongside current weight (optional, default -1)
+ * @param fault    Indicates if the scale has an error (optional, default false)
+ */
+void displayBrewWeight(int x, int y, float weight, float setpoint = -1, bool fault = false) {
+    if (fault) {
+        u8g2.setCursor(x, y);
+        u8g2.print(langstring_weight_rot_ur);
+        u8g2.print(langstring_scale_Failure);
+        return;
+    }
+
+    u8g2.setCursor(x, y);
+    u8g2.print(langstring_weight_rot_ur);
+    u8g2.print(weight, 0);
+
+    if (setpoint > 0) {
+        u8g2.print("/");
+        u8g2.print(setpoint, 0);
+    }
+
+    u8g2.print(" g");
+}
+
+/**
+ * @brief determines if brew timer should be visible; postBrewTimerDuration defines how long the timer after the brew is shown
+ * @return true if timer should be visible, false otherwise
+ */
+bool shouldDisplayBrewTimer() {
+
+    enum BrewTimerState {
+        kBrewTimerIdle = 10,
+        kBrewTimerRunning = 20,
+        kBrewTimerPostBrew = 30
+    };
+
+    static BrewTimerState currBrewTimerState = kBrewTimerIdle;
+
+    static uint32_t brewEndTime = 0;
+
+    switch (currBrewTimerState) {
+        case kBrewTimerIdle:
+            if (brew()) {
+                currBrewTimerState = kBrewTimerRunning;
+            }
+            break;
+
+        case kBrewTimerRunning:
+            if (!brew()) {
+                currBrewTimerState = kBrewTimerPostBrew;
+                brewEndTime = millis();
+            }
+            break;
+
+        case kBrewTimerPostBrew:
+            if ((millis() - brewEndTime) > (uint32_t)(postBrewTimerDuration * 1000)) {
+                currBrewTimerState = kBrewTimerIdle;
+            }
+            break;
+    }
+
+    return (currBrewTimerState != kBrewTimerIdle);
+}
+
+/**
  * @brief print logo and message at boot
  */
 void displayLogo(String displaymessagetext, String displaymessagetext2) {
+    int printrow = 47;
     u8g2.clearBuffer();
-    u8g2.drawStr(0, 47, displaymessagetext.c_str());
-    u8g2.drawStr(0, 55, displaymessagetext2.c_str());
+    // Create modifiable copies
+    char text1[displaymessagetext.length() + 1];
+    char text2[displaymessagetext2.length() + 1];
 
+    strcpy(text1, displaymessagetext.c_str());
+    strcpy(text2, displaymessagetext2.c_str());
+
+    char* token = strtok(text1, " ");
+    while (token != NULL) {
+        u8g2.drawStr(0, printrow, token);
+        token = strtok(NULL, " "); // Get the next token
+        printrow += 10;
+    }
+    token = strtok(text2, " ");
+    while (token != NULL) {
+        u8g2.drawStr(0, printrow, token);
+        token = strtok(NULL, " "); // Get the next token
+        printrow += 10;
+    }
     u8g2.drawXBMP(11, 4, CleverCoffee_Logo_width, CleverCoffee_Logo_height, CleverCoffee_Logo);
 
     u8g2.sendBuffer();
@@ -107,3 +260,125 @@ bool displayShottimer() {
     return false;
 }
 #endif
+
+void displayScrollingSubstring(int x, int y, int displayWidth, const char* text, bool bounce) {
+    static int offset = 0;
+    static int direction = 1;
+    static unsigned long lastUpdate = 0;
+    static unsigned long interval = 100;
+    static const char* lastText = nullptr;
+
+    if (text == nullptr) return;
+
+    // Reset if text has changed
+    if (lastText != text) {
+        offset = 0;
+        direction = 1;
+        lastText = text;
+        interval = 500;
+        lastUpdate = millis();
+    }
+    else if (offset > 0) {
+        interval = 100;
+    }
+
+    int textLen = strlen(text);
+    int fullTextWidth = u8g2.getStrWidth(text);
+
+    // limit display width
+    if ((displayWidth == 0) || (displayWidth + x > SCREEN_HEIGHT)) {
+        displayWidth = SCREEN_HEIGHT - x;
+    }
+
+    // No scrolling needed
+    if (fullTextWidth <= displayWidth) {
+        u8g2.drawStr(x, y, text);
+        return;
+    }
+
+    // Scroll logic
+    if (millis() - lastUpdate > interval) {
+        lastUpdate = millis();
+        if (bounce) {
+            offset += direction;
+            if (offset < 0 || u8g2.getStrWidth(&text[offset]) < displayWidth) {
+                direction = -direction;
+                offset += direction;
+            }
+        }
+        else {
+            offset++;
+            if (offset >= u8g2.getStrWidth(&text[offset])) {
+                offset = 0;
+            }
+        }
+    }
+
+    // Determine how many characters fit
+    int visibleWidth = 0;
+    int end = offset;
+    while (end < textLen && visibleWidth < displayWidth) {
+        char buf[2] = {text[end], '\0'};
+        visibleWidth += u8g2.getStrWidth(buf);
+        if (visibleWidth > displayWidth) break;
+        end++;
+    }
+
+    // Copy visible substring
+    char visible[64] = {0};
+    strncpy(visible, &text[offset], end - offset);
+    visible[end - offset] = '\0';
+
+    u8g2.drawStr(x, y, visible);
+}
+
+/**
+ * @brief display fullscreen brew timer
+ */
+bool displayFullscreenBrewTimer() {
+    if (featureFullscreenBrewTimer == 0) {
+        return false;
+    }
+
+    if (shouldDisplayBrewTimer()) {
+        u8g2.clearBuffer();
+        u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
+#if (FEATURE_SCALE == 1)
+        u8g2.setFont(u8g2_font_profont22_tf);
+        u8g2.setCursor(5, 70);
+        u8g2.print(currBrewTime / 1000, 1);
+        u8g2.print("s");
+        u8g2.setCursor(5, 100);
+        u8g2.print(currBrewWeight, 1);
+        u8g2.print("g");
+        u8g2.setFont(u8g2_font_profont11_tf);
+#else
+        displayBrewtimeFs(1, 80, currBrewTime);
+#endif
+        displayWaterIcon(55, 1);
+        u8g2.sendBuffer();
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * @brief display fullscreen manual flush timer
+ */
+bool displayFullscreenManualFlushTimer() {
+    if (featureFullscreenManualFlushTimer == 0) {
+        return false;
+    }
+
+    if (machineState == kManualFlush) {
+        u8g2.clearBuffer();
+        u8g2.drawXBMP(0, 12, Manual_Flush_Logo_width, Manual_Flush_Logo_height, Manual_Flush_Logo);
+        displayBrewtimeFs(1, 80, currBrewTime);
+        displayWaterIcon(55, 1);
+        u8g2.sendBuffer();
+        return true;
+    }
+
+    return false;
+}

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -25,83 +25,95 @@ void printScreen() {
     }
 
     // If no specific machine state was printed, print default:
+    u8g2.clearBuffer();
+    if (machineState == kWaterTankEmpty) { // Water empty
+        u8g2.drawXBMP(8, 50, Water_Tank_Empty_Logo_width, Water_Tank_Empty_Logo_height, Water_Tank_Empty_Logo);
+    }
+    else if (machineState == kSensorError) {
+        u8g2.setFont(u8g2_font_profont11_tf);
+        displayMessage(langstring_error_tsensor_rot_ur[0], langstring_error_tsensor_rot_ur[1], String(temperature), langstring_error_tsensor_rot_ur[2], langstring_error_tsensor_rot_ur[3], langstring_error_tsensor_rot_ur[4]);
+    }
+    else if (FEATURE_PIDOFF_LOGO == 1 && machineState == kStandby) {
+        u8g2.drawXBMP(6, 50, Off_Logo_width, Off_Logo_height, Off_Logo);
+        u8g2.setCursor(1, 110);
+        u8g2.setFont(u8g2_font_profont10_tf);
+        u8g2.print("Standby mode");
+    }
 
-    if ((machineState == kPidNormal || (machineState == kBrew && FEATURE_SHOTTIMER == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) && (brewSwitchState != kManualFlush) ||
-        (machineState == kWaterTankEmpty) || (machineState == kPidDisabled) || (machineState == kStandby) || (machineState == kSteam)) {
-        if (!tempSensor->hasError()) {
-            u8g2.clearBuffer();
-            u8g2.setFont(u8g2_font_profont11_tf);
-            u8g2.setCursor(1, 14);
-            u8g2.print(langstring_current_temp_rot_ur);
+    else {
+        u8g2.setFont(u8g2_font_profont11_tf);
+        u8g2.setCursor(1, 14);
+        u8g2.print(langstring_current_temp_rot_ur);
+        u8g2.print(temperature, 1);
+        u8g2.print(" ");
+        u8g2.print((char)176);
+        u8g2.print("C");
+        u8g2.setCursor(1, 24);
+        u8g2.print(langstring_set_temp_rot_ur);
+        u8g2.print(setpoint, 1);
+        u8g2.print(" ");
+        u8g2.print((char)176);
+        u8g2.print("C");
+
+        // Draw heat bar
+        u8g2.drawLine(0, 124, 63, 124);
+        u8g2.drawLine(0, 124, 0, 127);
+        u8g2.drawLine(64, 124, 63, 127);
+        u8g2.drawLine(0, 127, 63, 127);
+        u8g2.drawLine(1, 125, (pidOutput / 16.13) + 1, 125);
+        u8g2.drawLine(1, 126, (pidOutput / 16.13) + 1, 126);
+
+        if (FEATURE_PIDOFF_LOGO == 1 && machineState == kPidDisabled) {
+
+            u8g2.drawXBMP(6, 50, Off_Logo_width, Off_Logo_height, Off_Logo);
+            u8g2.setCursor(1, 110);
+            u8g2.setFont(u8g2_font_profont10_tf);
+            u8g2.print("PID disabled");
+        }
+
+        // Steam
+        else if (machineState == kSteam) {
+            u8g2.drawXBMP(12, 50, Steam_Logo_width, Steam_Logo_height, Steam_Logo);
+        }
+
+        // Show the heating logo when we are in regular PID mode
+        if (FEATURE_HEATINGLOGO > 0 && machineState == kPidNormal && (setpoint - temperature) > 0.3) {
+            // For status info
+
+            u8g2.drawXBMP(12, 50, Heating_Logo_width, Heating_Logo_height, Heating_Logo);
+            u8g2.setFont(u8g2_font_fub17_tf);
+            u8g2.setCursor(8, 90);
             u8g2.print(temperature, 1);
-            u8g2.print(" ");
-            u8g2.print((char)176);
-            u8g2.print("C");
-            u8g2.setCursor(1, 24);
-            u8g2.print(langstring_set_temp_rot_ur);
-            u8g2.print(setpoint, 1);
-            u8g2.print(" ");
-            u8g2.print((char)176);
-            u8g2.print("C");
+        }
+        else {
+// print heating status
+#if (FEATURE_SCALE == 1) && (FEATURE_PRESSURESENSOR == 1)
+            u8g2.setCursor(1, 64);
+#elif (FEATURE_SCALE == 1) || (FEATURE_PRESSURESENSOR == 1)
+            u8g2.setCursor(1, 60);
+#else
+            u8g2.setCursor(1, 50);
+#endif
 
-            // Draw heat bar
-            u8g2.drawLine(0, 124, 63, 124);
-            u8g2.drawLine(0, 124, 0, 127);
-            u8g2.drawLine(64, 124, 63, 127);
-            u8g2.drawLine(0, 127, 63, 127);
-            u8g2.drawLine(1, 125, (pidOutput / 16.13) + 1, 125);
-            u8g2.drawLine(1, 126, (pidOutput / 16.13) + 1, 126);
+            u8g2.setFont(u8g2_font_profont22_tf);
 
-            // Show the heating logo when we are in regular PID mode
-            if (FEATURE_HEATINGLOGO > 0 && machineState == kPidNormal && (setpoint - temperature) > 0.3) {
-                // For status info
-
-                u8g2.drawXBMP(12, 50, Heating_Logo_width, Heating_Logo_height, Heating_Logo);
-                u8g2.setFont(u8g2_font_fub17_tf);
-                u8g2.setCursor(8, 90);
-                u8g2.print(temperature, 1);
-            }
-            // Offline logo
-            else if (FEATURE_PIDOFF_LOGO == 1 && machineState == kPidDisabled) {
-
-                u8g2.drawXBMP(6, 50, Off_Logo_width, Off_Logo_height, Off_Logo);
-                u8g2.setCursor(1, 110);
-                u8g2.setFont(u8g2_font_profont10_tf);
-                u8g2.print("PID disabled");
-            }
-            else if (FEATURE_PIDOFF_LOGO == 1 && machineState == kStandby) {
-
-                u8g2.drawXBMP(6, 50, Off_Logo_width, Off_Logo_height, Off_Logo);
-                u8g2.setCursor(1, 110);
-                u8g2.setFont(u8g2_font_profont10_tf);
-                u8g2.print("Standby mode");
-            }
-            // Steam
-            else if (machineState == kSteam) {
-
-                u8g2.drawXBMP(12, 50, Steam_Logo_width, Steam_Logo_height, Steam_Logo);
-            }
-            // Water empty
-            else if (machineState == kWaterEmpty) {
-                u8g2.drawXBMP(8, 50, Water_Empty_Logo_width, Water_Empty_Logo_height, Water_Empty_Logo);
-            }
-            else {
-
-                // print heating status
-                u8g2.setCursor(1, 50);
-                u8g2.setFont(u8g2_font_profont22_tf);
-
-                if (fabs(temperature - setpoint) < 0.3) {
-                    if (isrCounter < 500) {
+            if (fabs(temperature - setpoint) < 0.3) {
+                if (isrCounter < 500) {
+                    if (featureBrewControl && machineState == kManualFlush) {
+                        u8g2.print("FLUSH"); // no flush function if optocoupler? manual flush is still triggered if momentary
+                    }
+                    else if (shouldDisplayBrewTimer()) {
+                        u8g2.print("BREW");
+                    }
+                    else {
                         u8g2.print("OK");
                     }
                 }
-                else {
-                    u8g2.print("WAIT");
-                }
-
-                u8g2.setFont(u8g2_font_profont11_tf);
             }
+            else {
+                u8g2.print("WAIT");
+            }
+            u8g2.setFont(u8g2_font_profont11_tf);
 
             // PID values above heater output bar
             u8g2.setCursor(1, 84);
@@ -117,79 +129,79 @@ void printScreen() {
             else {
                 u8g2.print("0");
             }
-
             u8g2.setCursor(1, 102);
             u8g2.print("D: ");
             u8g2.print(bPID.GetKd() / bPID.GetKp(), 0);
-
             u8g2.setCursor(1, 111);
-
             if (pidOutput < 99) {
                 u8g2.print(pidOutput / 10, 1);
             }
             else {
                 u8g2.print(pidOutput / 10, 0);
             }
-
             u8g2.print("%");
-
             // Brew
-            u8g2.setCursor(1, 34);
-            u8g2.print(langstring_brew_rot_ur);
-            u8g2.print(currBrewTime / 1000, 0);
-
-            if (FEATURE_BREWCONTROL == 1) {
-                u8g2.print("/");
-                u8g2.print(totalTargetBrewTime / 1000, 0);
+            displayBrewTime(1, 34, langstring_brew_rot_ur, currBrewTime, totalTargetBrewTime);
+#if (FEATURE_SCALE == 1)
+            displayBrewWeight(1, 44, currReadingWeight, -1, scaleFailure);
+#endif
+#if (FEATURE_PRESSURESENSOR == 1)
+            u8g2.setFont(u8g2_font_profont11_tf);
+            if (FEATURE_SCALE == 1) {
+                u8g2.setCursor(1, 54);
             }
-
-            u8g2.print(" s");
-        }
-
-        // Brew time
+            else {
+                u8g2.setCursor(1, 44);
+            }
+            u8g2.print(langstring_pressure_rot_ur);
+            u8g2.print(inputPressure, 1);
+            u8g2.print(" bar");
+#endif
+            // Brew time
 #if (FEATURE_BREWSWITCH == 1)
-        if (featureBrewControl) {
-            // Show brew time
-            if (shouldDisplayBrewTimer()) {
-                u8g2.setCursor(1, 34);
-                u8g2.print(langstring_brew_rot_ur);
-                u8g2.print(currBrewTime / 1000, 0);
-                u8g2.print("/");
-                u8g2.print(totalTargetBrewTime / 1000, 0);
-                u8g2.print(" s");
+            if (featureBrewControl) {
+                // Show brew time
+                if (shouldDisplayBrewTimer()) {
+                    displayBrewTime(1, 34, langstring_brew_rot_ur, currBrewTime, totalTargetBrewTime);
+#if (FEATURE_SCALE == 1)
+                    u8g2.setDrawColor(0);
+                    u8g2.drawBox(1, 45, 100, 10);
+                    u8g2.setDrawColor(1);
+                    displayBrewWeight(1, 44, currBrewWeight, targetBrewWeight, scaleFailure);
+#endif
+                }
+                // Shown flush time
+                if (machineState == kManualFlush) {
+                    u8g2.setDrawColor(0);
+                    u8g2.drawBox(1, 35, 100, 10);
+                    u8g2.setDrawColor(1);
+                    displayBrewTime(1, 34, langstring_manual_flush_rot_ur, currBrewTime);
+                }
             }
-
-            // Shown flush time
-            if (machineState == kManualFlush) {
-                u8g2.setDrawColor(0);
-                u8g2.drawBox(1, 34, 100, 15);
-                u8g2.setDrawColor(1);
-                u8g2.setCursor(1, 34);
-                u8g2.print(langstring_manual_flush_rot_ur);
-                u8g2.print(currBrewTime / 1000, 0);
-                u8g2.print(" s");
-            }
-        }
-        else {
-            // Show brew time with optocoupler
-            if (shouldDisplayBrewTimer()) {
-                u8g2.setCursor(1, 34);
-                u8g2.print(langstring_brew_rot_ur);
-                u8g2.print(currBrewTime / 1000, 0);
-                u8g2.print(" s");
+            else {
+                // Show brew time with optocoupler
+                if (shouldDisplayBrewTimer()) {
+                    u8g2.setDrawColor(0);
+                    u8g2.drawBox(1, 35, 100, 10);
+                    u8g2.setDrawColor(1);
+                    displayBrewTime(1, 34, langstring_brew_rot_ur, currBrewTime);
+#if (FEATURE_SCALE == 1)
+                    u8g2.setDrawColor(0);
+                    u8g2.drawBox(1, 45, 100, 10);
+                    u8g2.setDrawColor(1);
+                    displayBrewWeight(1, 44, currBrewWeight, -1, scaleFailure);
+#endif
+                }
             }
         }
 #endif
 
         // For status info
         u8g2.drawFrame(0, 0, 64, 12);
-
         if (offlineMode == 0) {
             getSignalStrength();
-
             if (WiFi.status() == WL_CONNECTED) {
                 u8g2.drawXBMP(4, 2, 8, 8, Antenna_OK_Icon);
-
                 for (int b = 0; b <= getSignalStrength(); b++) {
                     u8g2.drawVLine(13 + (b * 2), 10 - (b * 2), b * 2);
                 }
@@ -199,12 +211,11 @@ void printScreen() {
                 u8g2.print("");
             }
         }
-    }
-    else {
-        u8g2.setCursor(4, 1);
-        u8g2.print("Offline");
+        else {
+            u8g2.setCursor(4, 1);
+            u8g2.print("Offline");
+        }
     }
 
     u8g2.sendBuffer();
-}
 }

--- a/src/languages.h
+++ b/src/languages.h
@@ -23,6 +23,9 @@ static const char* langstring_set_temp_rot_ur = "S: ";
 static const char* langstring_current_temp_rot_ur = "I: ";
 static const char* langstring_brew_rot_ur = "B: ";
 static const char* langstring_manual_flush_rot_ur = "S: ";
+static const char* langstring_weight_rot_ur = "G: ";
+static const char* langstring_pressure_rot_ur = "D: ";
+static const char* langstring_error_tsensor_rot_ur[] = {"Fehler", "Temp: ", "Temp.", "Sensor", "ueberpruefen!"};
 #endif
 
 static const char* langstring_offlinemode = "Offline";
@@ -52,6 +55,9 @@ static const char* langstring_set_temp_rot_ur = "S: ";
 static const char* langstring_current_temp_rot_ur = "T: ";
 static const char* langstring_brew_rot_ur = "B: ";
 static const char* langstring_manual_flush_rot_ur = "F: ";
+static const char* langstring_weight_rot_ur = "W: ";
+static const char* langstring_pressure_rot_ur = "P: ";
+static const char* langstring_error_tsensor_rot_ur[] = {"Error", "Temp: ", "check", "temp.", "sensor!"};
 #endif
 
 static const char* langstring_offlinemode = "Offline";
@@ -82,6 +88,9 @@ static const char* langstring_set_temp_rot_ur = "O: ";
 static const char* langstring_current_temp_rot_ur = "T: ";
 static const char* langstring_brew_rot_ur = "B: ";
 static const char* langstring_manual_flush_rot_ur = "F: ";
+static const char* langstring_weight_rot_ur = "P: ";
+static const char* langstring_pressure_rot_ur = "Pr: ";
+static const char* langstring_error_tsensor_rot_ur[] = {"Error", "Temp: ", "Comprueba", "sensor", "T!"};
 #endif
 
 static const char* langstring_offlinemode = "Offline";

--- a/src/scaleHandler.h
+++ b/src/scaleHandler.h
@@ -138,10 +138,7 @@ void initScale() {
 
     if (LoadCell.getTareTimeoutFlag() || LoadCell.getSignalTimeoutFlag()) {
         LOG(ERROR, "Timeout, check MCU>HX711 wiring for scale");
-        u8g2.clearBuffer();
-        u8g2.drawStr(0, 32, "failed!");
-        u8g2.drawStr(0, 42, "Scale not working..."); // scale timeout will most likely trigger after OTA update, but will still work after boot
-        u8g2.sendBuffer();
+        displayScaleFailed(); // scale timeout will most likely trigger after OTA update, but will still work after boot
         delay(5000);
         scaleFailure = true;
         return;
@@ -150,10 +147,7 @@ void initScale() {
 #if SCALE_TYPE == 0
     if (LoadCell2.getTareTimeoutFlag() || LoadCell2.getSignalTimeoutFlag()) {
         LOG(ERROR, "Timeout, check MCU>HX711 wiring for scale 2");
-        u8g2.clearBuffer();
-        u8g2.drawStr(0, 32, "failed!");
-        u8g2.drawStr(0, 42, "Scale not working..."); // scale timeout will most likely trigger after OTA update, but will still work after boot
-        u8g2.sendBuffer();
+        displayScaleFailed(); // scale timeout will most likely trigger after OTA update, but will still work after boot
         delay(5000);
         scaleFailure = true;
         return;


### PR DESCRIPTION
These are the changes I made to make the upright display usable. It follows the original display style and automatically adjusts based on pressure sensor and weight availability.

There are some improvements to make, like in the full screen timers.

There is a scrolling substring function in Common and RotateUpright that I'm using in my own build but not specifically used here.