### PR TITLE
Fix steam LED clash with serial monitoring

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1437,15 +1437,18 @@ void setup() {
 
     if (LED_TYPE == LED::STANDARD) {
         statusLedPin = new GPIOPin(PIN_STATUSLED, GPIOPin::OUT);
-        brewLedPin = new GPIOPin(PIN_BREWLED, GPIOPin::OUT);
-        steamLedPin = new GPIOPin(PIN_STEAMLED, GPIOPin::OUT);
-
         statusLed = new StandardLED(*statusLedPin, FEATURE_STATUS_LED);
-        brewLed = new StandardLED(*brewLedPin, FEATURE_BREW_LED);
-        steamLed = new StandardLED(*steamLedPin, FEATURE_STEAM_LED);
 
+        brewLedPin = new GPIOPin(PIN_BREWLED, GPIOPin::OUT);
+        brewLed = new StandardLED(*brewLedPin, FEATURE_BREW_LED);
         brewLed->turnOff();
+
+// directive required due to conflicts with TX0, Steam LED must be disabled when using USB for monitoring
+#if FEATURE_STEAM_LED
+        steamLedPin = new GPIOPin(PIN_STEAMLED, GPIOPin::OUT);
+        steamLed = new StandardLED(*steamLedPin, FEATURE_STEAM_LED);
         steamLed->turnOff();
+#endif
     }
     else {
         // TODO Addressable LEDs
@@ -1755,8 +1758,13 @@ void loopLED() {
     else {
         statusLed->turnOff();
     }
+
     brewLed->setGPIOState(machineState == kBrew);
+
+// directive required due to conflicts with TX0, Steam LED must be disabled when using USB for monitoring
+#if FEATURE_STEAM_LED
     steamLed->setGPIOState(machineState == kSteam);
+#endif
 }
 
 void checkWaterTank() {

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -48,7 +48,7 @@
 #define PUMP_VALVE_SSR_TYPE     Relay::HIGH_TRIGGER     // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER
 #define FEATURE_STATUS_LED      0                       // Blink status LED when temp is in range, 0 = deactivated, 1 = activated, 2 = activated inverted
 #define FEATURE_BREW_LED        0                       // Turn on brew LED when brew is started, 0 = deactivated, 1 = activated, 2 = activated inverted
-#define FEATURE_STEAM_LED       0                       // Turn on steam LED when switch is started, 0 = deactivated, 1 = activated, 2 = activated inverted
+#define FEATURE_STEAM_LED       0                       // Turn on steam LED when switch is started, 0 = deactivated, 1 = activated, 2 = activated inverted. Only use steam LED if not using USB monitoring
 #define LED_TYPE                LED::STANDARD           // STANDARD_LED for an LED connected to a GPIO pin, WS2812 for adressable LEDs
 #define FEATURE_WATERTANKSENSOR 0                       // 0 = deactivated, 1 = activated
 #define WATERTANKSENSOR_TYPE    Switch::NORMALLY_CLOSED // Switch::NORMALLY_CLOSED for sensor XKC-Y25-NPN or Switch::NORMALLY_OPEN for XKC-Y25-PNP


### PR DESCRIPTION
Added #if to steam LED initialisation and usage due to conflicts with TX0 pin, where it would either reboot or not show any log data.

Only require #if FEATURE_STEAM_LED as both 1 and 2 evaluate to true.

The first entries for Steam LED do not need it as the issue is only when a pin is assigned.

The fix does not impact users with wifi monitoring.