### PR TITLE
remove brew(), manualFlush() call outside main state machine

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1645,11 +1645,6 @@ void looppid() {
     shottimerscale(); // Calculation of weight of shot while brew is running
 #endif
 
-#if (FEATURE_BREWSWITCH == 1)
-    brew();
-    manualFlush();
-#endif
-
 #if (FEATURE_PRESSURESENSOR == 1)
     unsigned long currentMillisPressure = millis();
 


### PR DESCRIPTION
these functions should only be possible if in the right machine state