### PR TITLE
fixed reading second scale

### DIFF
--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -71,14 +71,11 @@ inline int currBackflushCycles = 1;
 inline boolean scaleCalibrationOn = false;
 inline boolean scaleTareOn = false;
 inline int shottimerCounter = 10;
-inline float calibrationValue = SCALE_CALIBRATION_FACTOR; // use calibration example to get value
-inline float currReadingWeight = 0;                       // value from HX711
-inline float prewBrewWeight = 0;                          // value of scale before brew started
-inline float currBrewWeight = 0;                          // weight value of current brew
-inline float scaleDelayValue = 2.5;                       // value in gramm that takes still flows onto the scale after brew is stopped
+inline float currReadingWeight = 0; // value from HX711
+inline float prewBrewWeight = 0;    // value of scale before brew started
+inline float currBrewWeight = 0;    // weight value of current brew
+inline float scaleDelayValue = 2.5; // value in gramm that takes still flows onto the scale after brew is stopped
 inline bool scaleFailure = false;
-constexpr unsigned long intervalWeight = 200;             // weight scale
-inline unsigned long previousMillisScale;                 // initialisation at the end of init()
 inline HX711_ADC LoadCell(PIN_HXDAT, PIN_HXCLK);
 inline HX711_ADC LoadCell2(PIN_HXDAT2, PIN_HXCLK);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,7 @@ double emaFactor = EMA_FACTOR;
 
 // Scale
 float scaleCalibration = SCALE_CALIBRATION_FACTOR;
-float scale2Calibration = SCALE_CALIBRATION_FACTOR;
+float scale2Calibration = SCALE2_CALIBRATION_FACTOR;
 float scaleKnownWeight = SCALE_KNOWN_WEIGHT;
 double targetBrewWeight = TARGET_BREW_WEIGHT;
 
@@ -1050,7 +1050,6 @@ void setup() {
     // Init Scale
     if (config.get<bool>("hardware.sensors.scale.enabled")) {
         initScale();
-        previousMillisScale = currentTime;
     }
 
     if (config.get<bool>("hardware.sensors.pressure.enabled")) {


### PR DESCRIPTION
The second load cell reading would pause often due to shared clock pin. This fix a;ternates which load cell is read using a boolean flag, providing fast response using the 10hz update rate of the hx711 to read each at 5hz.

An alternative fix would be to clock the pin manually and read both scale data pins for each clock pulse. This is a future option if 5hz refreshes are not fast enough.

The millis() timing has been removed as the data lines are checked for new data.

There was some missing logic for scale samples and the code was only reading the first scale, these have been fixed.