### PR TITLE
Timing optimisations to reduce stutter

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -9,19 +9,19 @@ This document describes all configuration parameters available in the `config.js
 ### `backflush.cycles`
 - **Type**: Integer
 - **Default**: `5`
-- **Range**: 1-20
+- **Range**: 2-20
 - **Description**: Number of backflush cycles to perform during cleaning
 
 ### `backflush.fill_time`
 - **Type**: Double (seconds)
 - **Default**: `5.0`
-- **Range**: 1.0-30.0
+- **Range**: 3.0-10.0
 - **Description**: Time to fill the group head with cleaning solution
 
 ### `backflush.flush_time`
 - **Type**: Double (seconds)
 - **Default**: `10.0`
-- **Range**: 1.0-60.0
+- **Range**: 5.0-20.0
 - **Description**: Time to flush cleaning solution back through the 3-way valve into the drip tray
 
 ---
@@ -43,7 +43,7 @@ This document describes all configuration parameters available in the `config.js
 ### `brew.temp_offset`
 - **Type**: Double (°C)
 - **Default**: `0.0`
-- **Range**: -25.0-25.0
+- **Range**: 0.0-20.0
 - **Description**: Temperature offset to compensate for sensor placement or other dropoff
 
 ### `brew.target_time`
@@ -55,7 +55,7 @@ This document describes all configuration parameters available in the `config.js
 ### `brew.target_weight`
 - **Type**: Double (grams)
 - **Default**: `30.0`
-- **Range**: 0.1-500.0
+- **Range**: 0.0-500.0
 - **Description**: Target output weight for automatic brewing (requires scale)
 
 ## Pre-Infusion Settings
@@ -63,7 +63,7 @@ This document describes all configuration parameters available in the `config.js
 ### `brew.pre_infusion.time`
 - **Type**: Double (seconds)
 - **Default**: `2.0`
-- **Range**: 0.0-30.0
+- **Range**: 0.0-60.0
 - **Description**: Duration of pre-infusion phase
 
 ### `brew.pre_infusion.pause`
@@ -108,7 +108,7 @@ This document describes all configuration parameters available in the `config.js
 ### `display.post_brew_timer_duration`
 - **Type**: Double (seconds)
 - **Default**: `3.0`
-- **Range**: 0.0-30.0
+- **Range**: 0.0-60.0
 - **Description**: Duration to show shot timer post-brew
 
 ### `display.template`
@@ -231,7 +231,7 @@ For each LED type (status, brew, steam):
 ##### `hardware.sensors.scale.known_weight`
 - **Type**: Double (grams)
 - **Default**: `267.0`
-- **Range**: 1.0-10000.0
+- **Range**: 1.0-2000.0
 - **Description**: Known weight for calibration
 
 ##### `hardware.sensors.scale.samples`
@@ -370,13 +370,13 @@ For each switch type (brew, power, steam):
 ### `pid.regular.tn`
 - **Type**: Double (seconds)
 - **Default**: `52.0`
-- **Range**: 0.0-9999.0
+- **Range**: 0.0-200.0
 - **Description**: Integral time constant
 
 ### `pid.regular.tv`
 - **Type**: Double (seconds)
 - **Default**: `11.5`
-- **Range**: 0.0-9999.0
+- **Range**: 0.0-200.0
 - **Description**: Derivative time constant
 
 ### `pid.regular.i_max`
@@ -401,13 +401,13 @@ For each switch type (brew, power, steam):
 ### `pid.bd.tn`
 - **Type**: Double (seconds)
 - **Default**: `0.0`
-- **Range**: 0.0-9999.0
+- **Range**: 0.0-200.0
 - **Description**: Brew detection integral time constant
 
 ### `pid.bd.tv`
 - **Type**: Double (seconds)
 - **Default**: `20.0`
-- **Range**: 0.0-9999.0
+- **Range**: 0.0-200.0
 - **Description**: Brew detection derivative time constant
 
 ## Steam PID Parameters
@@ -430,7 +430,7 @@ For each switch type (brew, power, steam):
 ### `standby.time`
 - **Type**: Double (minutes)
 - **Default**: `30.0`
-- **Range**: 1.0-999.0
+- **Range**: 1.0-120.0
 - **Description**: Time before entering standby mode
 
 ---

--- a/data/js/app.js
+++ b/data/js/app.js
@@ -110,7 +110,8 @@ const vueApp = Vue.createApp({
                     return response.text();
                 })
                 .then(data => {
-                    // Parameters saved successfully
+                    // Parameters saved successfully - now re-fetch to get updated show conditions
+                    this.fetchParameters(this.filter);
                 })
                 .catch(err => {
                     console.error("Error saving parameters:", err);

--- a/src/Config.h
+++ b/src/Config.h
@@ -305,6 +305,11 @@ class Config {
             _configDefs.emplace("system.auth.username", ConfigDef::forString(AUTH_USERNAME, USERNAME_MAX_LENGTH));
             _configDefs.emplace("system.auth.password", ConfigDef::forString(AUTH_PASSWORD, PASSWORD_MAX_LENGTH));
 
+            // Debugging
+            _configDefs.emplace("system.timing_debug.enabled", ConfigDef::forBool(false));
+            _configDefs.emplace("system.timing.enabled", ConfigDef::forBool(false));
+            _configDefs.emplace("system.showdisplay.enabled", ConfigDef::forBool(true));
+
             // Display
             _configDefs.emplace("display.template", ConfigDef::forInt(0, 0, 4));
             _configDefs.emplace("display.inverted", ConfigDef::forBool(false));

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -48,6 +48,9 @@ extern bool scaleTareOn;
 extern bool scaleCalibrationOn;
 extern int logLevel;
 extern const char sysVersion[64];
+extern bool timingMaster;         // if set to false it lets processes run together, if true it limits how many processes run per loop
+extern bool includeDisplayInLogs; // if set to true it shows every display update, if false it only shows if > 45ms or if running in the same loop as another process
+extern bool timingDebugActive;
 
 void ParameterRegistry::initialize(Config& config) {
     if (_ready) {
@@ -722,6 +725,43 @@ void ParameterRegistry::initialize(Config& config) {
         "Password for accessing the website and authenticating web requests."
     );
 
+    // Debugging Checkboxes
+    addBoolConfigParam(
+        "system.timing_debug.enabled",
+        "Loop timing in console",
+        sSystemSection,
+        1301,
+        &timingDebugActive,
+        "Enable or disable the process loop time debugging in console.<br>"
+        "r=draw display buffer<br>"
+        "D=display refresh<br>"
+        "W=website<br>"
+        "M=MQTT<br>"
+        "H=hassio<br>"
+        "T=temperature",
+        [&config] { return config.get<int>("system.log_level") == static_cast<int>(Logger::Level::DEBUG); }
+    );
+    
+    addBoolConfigParam(
+        "system.timing.enabled",
+        "Activate loop process limit",
+        sSystemSection,
+        1302,
+        &timingMaster,
+        "Enable or disable the process limit per loop",
+        [&config] { return config.get<int>("system.log_level") == static_cast<int>(Logger::Level::DEBUG); }
+    );
+
+    addBoolConfigParam(
+        "system.showdisplay.enabled",
+        "Activate display recording in debug logs",
+        sSystemSection,
+        1303,
+        &includeDisplayInLogs,
+        "Enable or disable showing sendBuffer loops in debug logs",
+        [&config] { return config.get<int>("system.log_level") == static_cast<int>(Logger::Level::DEBUG); }
+    );
+    
     // Hardware section
 
     // OLED
@@ -858,7 +898,7 @@ void ParameterRegistry::initialize(Config& config) {
         2222,
         nullptr,
         (const char* const[]){"Momentary", "Toggle"},
-        3,
+        2,
         "Type of power switch connected"
     );
 

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -48,8 +48,7 @@ extern bool scaleTareOn;
 extern bool scaleCalibrationOn;
 extern int logLevel;
 extern const char sysVersion[64];
-extern bool timingMaster;         // if set to false it lets processes run together, if true it limits how many processes run per loop
-extern bool includeDisplayInLogs; // if set to true it shows every display update, if false it only shows if > 45ms or if running in the same loop as another process
+extern bool includeDisplayInLogs;
 extern bool timingDebugActive;
 
 void ParameterRegistry::initialize(Config& config) {
@@ -741,16 +740,6 @@ void ParameterRegistry::initialize(Config& config) {
         "T=temperature",
         [&config] { return config.get<int>("system.log_level") == static_cast<int>(Logger::Level::DEBUG); }
     );
-    
-    addBoolConfigParam(
-        "system.timing.enabled",
-        "Activate loop process limit",
-        sSystemSection,
-        1302,
-        &timingMaster,
-        "Enable or disable the process limit per loop",
-        [&config] { return config.get<int>("system.log_level") == static_cast<int>(Logger::Level::DEBUG); }
-    );
 
     addBoolConfigParam(
         "system.showdisplay.enabled",
@@ -761,7 +750,7 @@ void ParameterRegistry::initialize(Config& config) {
         "Enable or disable showing sendBuffer loops in debug logs",
         [&config] { return config.get<int>("system.log_level") == static_cast<int>(Logger::Level::DEBUG); }
     );
-    
+
     // Hardware section
 
     // OLED

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -53,19 +53,19 @@
 #define AUTH_USERNAME             "admin"           // default username for web authentication
 
 #define PID_KP_REGULAR_MIN            0.0
-#define PID_KP_REGULAR_MAX            999.0
+#define PID_KP_REGULAR_MAX            200.0
 #define PID_TN_REGULAR_MIN            0.0
-#define PID_TN_REGULAR_MAX            999.0
+#define PID_TN_REGULAR_MAX            200.0
 #define PID_TV_REGULAR_MIN            0.0
-#define PID_TV_REGULAR_MAX            999.0
+#define PID_TV_REGULAR_MAX            200.0
 #define PID_I_MAX_REGULAR_MIN         0.0
-#define PID_I_MAX_REGULAR_MAX         999.0
+#define PID_I_MAX_REGULAR_MAX         100.0
 #define PID_KP_BD_MIN                 0.0
-#define PID_KP_BD_MAX                 999.0
+#define PID_KP_BD_MAX                 200.0
 #define PID_TN_BD_MIN                 0.0
-#define PID_TN_BD_MAX                 999.0
+#define PID_TN_BD_MAX                 200.0
 #define PID_TV_BD_MIN                 0.0
-#define PID_TV_BD_MAX                 999.0
+#define PID_TV_BD_MAX                 200.0
 #define PID_EMA_FACTOR_MIN            0.0
 #define PID_EMA_FACTOR_MAX            1.0
 #define BREW_SETPOINT_MIN             20.0
@@ -74,8 +74,8 @@
 #define STEAM_SETPOINT_MAX            140.0
 #define BREW_TEMP_OFFSET_MIN          0.0
 #define BREW_TEMP_OFFSET_MAX          20.0
-#define TARGET_BREW_TIME_MIN          0.0
-#define TARGET_BREW_TIME_MAX          180.0
+#define TARGET_BREW_TIME_MIN          1.0
+#define TARGET_BREW_TIME_MAX          120.0
 #define BREW_PID_DELAY_MIN            0.0
 #define BREW_PID_DELAY_MAX            60.0
 #define PRE_INFUSION_TIME_MIN         0.0
@@ -86,7 +86,7 @@
 #define TARGET_BREW_WEIGHT_MAX        500.0
 #define PID_KP_STEAM_MIN              0.0
 #define PID_KP_STEAM_MAX              500.0
-#define STANDBY_MODE_TIME_MIN         30.0
+#define STANDBY_MODE_TIME_MIN         1.0
 #define STANDBY_MODE_TIME_MAX         120.0
 #define BACKFLUSH_CYCLES_MIN          2
 #define BACKFLUSH_CYCLES_MAX          20
@@ -96,11 +96,11 @@
 #define BACKFLUSH_FLUSH_TIME_MAX      20.0
 #define POST_BREW_TIMER_DURATION_MIN  0.0
 #define POST_BREW_TIMER_DURATION_MAX  60.0
-#define SCALE_CALIBRATION_MIN         0.01
-#define SCALE_CALIBRATION_MAX         10000.0
-#define SCALE2_CALIBRATION_MIN        0.01
-#define SCALE2_CALIBRATION_MAX        10000.0
-#define SCALE_KNOWN_WEIGHT_MIN        0.0
+#define SCALE_CALIBRATION_MIN         -999999.0
+#define SCALE_CALIBRATION_MAX         999999.0
+#define SCALE2_CALIBRATION_MIN        -999999.0
+#define SCALE2_CALIBRATION_MAX        999999.0
+#define SCALE_KNOWN_WEIGHT_MIN        1.0
 #define SCALE_KNOWN_WEIGHT_MAX        2000.0
 #define MQTT_BROKER_MAX_LENGTH        64
 #define USERNAME_MAX_LENGTH           32

--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -35,12 +35,15 @@ inline void u8g2_prepare() {
     u8g2->setDrawColor(1);
     u8g2->setFontPosTop();
     u8g2->setFontDirection(0);
+
     if (config.get<bool>("display.inverted")) {
         rotation += 2;
     }
+
     if (config.get<int>("display.template") == 4) {
         rotation++;
     }
+
     u8g2->setDisplayRotation(getU8G2Rotation(rotation));
 }
 
@@ -357,6 +360,7 @@ inline void displayBrewtimeFs(const int x, const int y, const double brewtime) {
 
         u8g2->print("s");
     }
+
     u8g2->setFont(u8g2_font_profont11_tf);
 }
 
@@ -467,6 +471,7 @@ inline bool displayFullscreenBrewTimer() {
 
     if (shouldDisplayBrewTimer()) {
         u8g2->clearBuffer();
+
         if (config.get<int>("display.template") == 4) {
             u8g2->drawXBMP(12, 12, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
 
@@ -483,6 +488,7 @@ inline bool displayFullscreenBrewTimer() {
             else {
                 displayBrewtimeFs(1, 80, currBrewTime);
             }
+
             displayWaterIcon(55, 2);
         }
         else {
@@ -504,7 +510,8 @@ inline bool displayFullscreenBrewTimer() {
 
             displayWaterIcon(119, 1);
         }
-        u8g2->sendBuffer();
+
+        displayBufferReady = true;
         return true;
     }
 
@@ -521,6 +528,7 @@ inline bool displayFullscreenManualFlushTimer() {
 
     if (machineState == kManualFlush) {
         u8g2->clearBuffer();
+
         if (config.get<int>("display.template") == 4) {
             u8g2->drawXBMP(12, 12, Manual_Flush_Logo_width, Manual_Flush_Logo_height, Manual_Flush_Logo);
             displayBrewtimeFs(1, 80, currBrewTime);
@@ -531,7 +539,8 @@ inline bool displayFullscreenManualFlushTimer() {
             displayBrewtimeFs(48, 25, currBrewTime);
             displayWaterIcon(119, 1);
         }
-        u8g2->sendBuffer();
+
+        displayBufferReady = true;
         return true;
     }
     return false;
@@ -541,11 +550,13 @@ inline bool displayFullscreenManualFlushTimer() {
  * @brief display offline message
  */
 inline bool displayOfflineMode() {
+
     if (displayOffline > 0 && displayOffline < 20) {
         displayMessage("", "", "", "", "Begin Fallback,", "No Wifi");
         displayOffline++;
         return true;
     }
+
     return false;
 }
 
@@ -553,6 +564,7 @@ inline bool displayOfflineMode() {
  * @brief display heating logo
  */
 inline bool displayMachineState() {
+
     if (displayOfflineMode()) {
         return true;
     }

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -111,5 +111,5 @@ inline void printScreen() {
     // Show heater output in %
     displayProgressbar(pidOutput / 10, 15, 60, 100);
 
-    u8g2->sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -125,5 +125,5 @@ inline void printScreen() {
     // Show heater output in %
     displayProgressbar(pidOutput / 10, 30, 60, 98);
 
-    u8g2->sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -116,5 +116,5 @@ inline void printScreen() {
     // Show heater output in %
     displayProgressbar(pidOutput / 10, 30, 60, 98);
 
-    u8g2->sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/display/displayTemplateTempOnly.h
+++ b/src/display/displayTemplateTempOnly.h
@@ -71,5 +71,5 @@ inline void printScreen() {
 
     displayStatusbar();
 
-    u8g2->sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -78,8 +78,8 @@ inline void printScreen() {
             u8g2->drawXBMP(12, 50, Steam_Logo_width, Steam_Logo_height, Steam_Logo);
         }
 
-        // Show the heating logo when we are in regular PID mode
-        else if (config.get<bool>("display.heating_logo") && machineState == kPidNormal && setpoint - temperature > 0.3) {
+        // Show the heating logo when we are in regular PID mode and more than 5degC below the set point
+        else if (config.get<bool>("display.heating_logo") && machineState == kPidNormal && setpoint - temperature > 5.0) {
             // For status info
             u8g2->drawXBMP(12, 50, Heating_Logo_width, Heating_Logo_height, Heating_Logo);
             u8g2->setFont(u8g2_font_fub17_tf);
@@ -87,6 +87,7 @@ inline void printScreen() {
             u8g2->print(temperature, 1);
         }
         else {
+            
             // print status
             if (scaleEnabled && pressureEnabled) {
                 u8g2->setCursor(1, 65);
@@ -106,8 +107,15 @@ inline void printScreen() {
             else if (shouldDisplayBrewTimer()) {
                 u8g2->print("BREW");
             }
-            else if ((fabs(temperature - setpoint) < 0.3) && (isrCounter < 500)) {
-                u8g2->print("OK");
+            else if (fabs(temperature - setpoint) < 0.3) {
+
+                if (isrCounter < 500) {
+                    u8g2->print("OK");
+                }
+                else {
+                    u8g2->print("");
+                }
+
             }
             else {
                 u8g2->print("WAIT");

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -87,7 +87,7 @@ inline void printScreen() {
             u8g2->print(temperature, 1);
         }
         else {
-            
+
             // print status
             if (scaleEnabled && pressureEnabled) {
                 u8g2->setCursor(1, 65);
@@ -115,7 +115,6 @@ inline void printScreen() {
                 else {
                     u8g2->print("");
                 }
-
             }
             else {
                 u8g2->print("WAIT");

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -221,5 +221,5 @@ inline void printScreen() {
         displayWaterIcon(55, 2);
     }
 
-    u8g2->sendBuffer();
+    displayBufferReady = true;
 }

--- a/src/hardware/TempSensor.h
+++ b/src/hardware/TempSensor.h
@@ -13,6 +13,8 @@
 #include "Logger.h"
 #include "utils/Timer.h"
 
+extern bool temperatureUpdateRunning;
+
 class TempSensor {
     public:
         /**
@@ -77,6 +79,7 @@ class TempSensor {
                 // Reset error counter and error state
                 bad_readings_ = 0;
                 error_ = false;
+                temperatureUpdateRunning = true;
 
                 // Update moving average
                 update_moving_average();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,6 @@ unsigned long previousMillisPressure; // initialisation at the end of init()
 
 // timing flags
 bool timingDebugActive = false;
-bool timingMaster = false;
 bool includeDisplayInLogs = false;
 bool displayBufferReady = false;
 bool displayUpdateRunning = false;
@@ -1142,7 +1141,7 @@ void loopPid() {
                 checkMQTT();
 
                 // if screen is ready to refresh wait for next loop
-                if ((!displayBufferReady && !temperatureUpdateRunning) || !timingMaster) {
+                if (!displayBufferReady && !temperatureUpdateRunning) {
                     writeSysParamsToMQTT(true); // Continue on error
                 }
             }
@@ -1156,7 +1155,7 @@ void loopPid() {
                 if (mqtt_hassio_enabled) {
                     // resend discovery messages if not during a main function and MQTT has been disconnected but has now reconnected
                     // this could mean mqtt_was_connected stays false for up to 5 mins but mqtt retains old HASSIO messages
-                    if (!((machineState >= kBrew) && (machineState <= kBackflush)) && ((!mqtt_was_connected && !displayBufferReady && !temperatureUpdateRunning) || !timingMaster)) {
+                    if (!(machineState >= kBrew && machineState <= kBackflush) && (!mqtt_was_connected && !displayBufferReady && !temperatureUpdateRunning)) {
                         hassioDiscoveryTimer();
                     }
                 }
@@ -1196,7 +1195,7 @@ void loopPid() {
     websiteUpdateRunning = false;
 
     // refresh website if loop does not have anoth long running process already
-    if (((millis() - lastTempEvent) > tempEventInterval) && ((!mqttUpdateRunning && !hassioUpdateRunning && !displayBufferReady && !temperatureUpdateRunning) || !timingMaster)) {
+    if (((millis() - lastTempEvent) > tempEventInterval) && (!mqttUpdateRunning && !hassioUpdateRunning && !displayBufferReady && !temperatureUpdateRunning)) {
         websiteUpdateRunning = true;
 
         // send temperatures to website endpoint
@@ -1266,7 +1265,7 @@ void loopPid() {
     if (config.get<bool>("hardware.oled.enabled")) {
 
         // update display on loops that have not had other major tasks running, if blocked it will send in the next loop (average 0.5ms)
-        if ((((!websiteUpdateRunning) && (!mqttUpdateRunning) && (!hassioUpdateRunning) && (!temperatureUpdateRunning)) || !timingMaster) && (standbyModeRemainingTimeDisplayOffMillis > 0)) {
+        if (!websiteUpdateRunning && !mqttUpdateRunning && !hassioUpdateRunning && !temperatureUpdateRunning && (standbyModeRemainingTimeDisplayOffMillis > 0)) {
 
             // displayUpdateRunning currently doesn't block anything as it is near the end of the loop, but if this code block moves it can be used to block other processes
             // sendBuffer() takes around 35ms so it flags that it has happened

--- a/src/utils/timingDebug.h
+++ b/src/utils/timingDebug.h
@@ -1,0 +1,164 @@
+/**
+ * @file timingDebug.h
+ *
+ * @brief Stores and prints long duration processes to the console if DEBUG is enabled
+ *
+ */
+
+#pragma once
+
+enum ActivityType : uint16_t {
+    ACT_DISPLAY_READY = 0x01,
+    ACT_DISPLAY_RUNNING = 0x02,
+    ACT_WEBSITE_RUNNING = 0x04,
+    ACT_MQTT_RUNNING = 0x08,
+    ACT_HASSIO_RUNNING = 0x10,
+    ACT_TEMPERATURE_RUNNING = 0x20
+};
+
+/**
+ * @brief print what has caused the long loop time
+ * @return void
+ */
+void printActivityFlags(const uint16_t* activity, int size) {
+    char activityBuffer[512];
+    int len = 0;
+
+    len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "Activity (short): [");
+
+    for (int i = 0; i < size; ++i) {
+
+        // Convert flags to short notation
+        if (activity[i] == 0) {
+            len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "_");
+        }
+        else {
+            // append a short ID tag based on what processes happened in the loop
+            if (activity[i] & ACT_DISPLAY_READY) {
+                len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "r");
+            }
+
+            if (activity[i] & ACT_DISPLAY_RUNNING) {
+                len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "D");
+            }
+
+            if (activity[i] & ACT_WEBSITE_RUNNING) {
+                len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "W");
+            }
+
+            if (activity[i] & ACT_MQTT_RUNNING) {
+                len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "M");
+            }
+
+            if (activity[i] & ACT_HASSIO_RUNNING) {
+                len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "H");
+            }
+
+            if (activity[i] & ACT_TEMPERATURE_RUNNING) {
+                len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "T");
+            }
+        }
+
+        if (i < size - 1) {
+            len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, ",");
+        }
+    }
+
+    len += snprintf(activityBuffer + len, sizeof(activityBuffer) - len, "]");
+    LOGF(DEBUG, "%s", activityBuffer);
+}
+
+/**
+ * @brief Print both timing and compact activity in one batch
+ * @return void
+ */
+void printTimingAndActivityBatch(const unsigned long* timing, const uint16_t* activity, int size) {
+    char timingBuffer[512];
+    int tLen = 0;
+
+    tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, "Loop timing (ms): [");
+
+    for (int i = 0; i < size; ++i) {
+        tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, "%lu", timing[i]);
+        if (i < size - 1) tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, ",");
+    }
+    tLen += snprintf(timingBuffer + tLen, sizeof(timingBuffer) - tLen, "]");
+
+    // Only two log lines total
+    LOGF(DEBUG, "%s", timingBuffer);
+    printActivityFlags(activity, size);
+}
+
+/**
+ * @brief Store all long duration activities and their loop times, send when array is full
+ * @return void
+ */
+void debugTimingLoop() {
+    static const int LOOP_HISTORY_SIZE = 20;
+    static unsigned long loopTiming[LOOP_HISTORY_SIZE];
+    static uint16_t activityType[LOOP_HISTORY_SIZE];
+    static unsigned long previousMillisDebug = millis();
+    static unsigned long lastSendMillisDebug = millis();
+    static unsigned int loopIndex = 0;
+    static unsigned int loopCount = 0;
+    static unsigned long maxLoop = 0;
+
+    IFLOG(DEBUG) {
+
+        if (timingDebugActive) {
+            loopCount += 1;
+            unsigned long loopDuration = millis() - previousMillisDebug;
+            previousMillisDebug = millis();
+
+            // the loopDuration > 45 check is in case there is a long loop caused by something unknown
+            // only record if one of these flags are set or loop has taken a long time
+            if ((loopDuration > 45) || ((displayUpdateRunning && includeDisplayInLogs) || websiteUpdateRunning || mqttUpdateRunning || hassioUpdateRunning || temperatureUpdateRunning)) {
+
+                if (loopDuration >= maxLoop) {
+                    maxLoop = loopDuration;
+                }
+
+                loopTiming[loopIndex] = loopDuration;
+                activityType[loopIndex] = 0;
+
+                // tag activityType with any activities that occured this loop
+                if (displayBufferReady) {
+                    activityType[loopIndex] |= ACT_DISPLAY_READY;
+                }
+
+                if (displayUpdateRunning) {
+                    activityType[loopIndex] |= ACT_DISPLAY_RUNNING;
+                }
+
+                if (websiteUpdateRunning) {
+                    activityType[loopIndex] |= ACT_WEBSITE_RUNNING;
+                }
+
+                if (mqttUpdateRunning) {
+                    activityType[loopIndex] |= ACT_MQTT_RUNNING;
+                }
+
+                if (hassioUpdateRunning) {
+                    activityType[loopIndex] |= ACT_HASSIO_RUNNING;
+                }
+
+                if (temperatureUpdateRunning) {
+                    activityType[loopIndex] |= ACT_TEMPERATURE_RUNNING;
+                }
+
+                loopIndex = (loopIndex + 1) % LOOP_HISTORY_SIZE;
+
+                // print to the last 20 entries to console
+                if (loopIndex == 0) {
+                    printTimingAndActivityBatch(loopTiming, activityType, LOOP_HISTORY_SIZE);
+                    unsigned long reportTime = millis() - lastSendMillisDebug;
+                    float avgLoopMs = loopCount > 0 ? ((float)reportTime / loopCount) : 0;
+                    LOGF(DEBUG, "Max time %lu (ms) -- %i entries report time %lu (ms) -- average %0.2f (ms)", maxLoop, LOOP_HISTORY_SIZE, reportTime, avgLoopMs);
+                    lastSendMillisDebug = millis();
+                    loopCount = 0;
+                    maxLoop = 0;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added process flags to reduce stuttering
Added MQTT filter to only send what has changed
Display updates in main screens are split into a draw loop then sendBuffer on the next loop
Block sending HASSIO discovery updates during critical tasks

Added tickbox to system menu to turn on and off the change (except splitting display), and added a tickbox to remove display updates from the logs to reduce frequency of sending log data.

The best way to test is to use the process limit tick box and compare how smooth the display updates are in a brew etc.
MQTT is a major source of stutters without the process limit, so you see pauses every 5 seconds.

This is an improved version from #542 

I expect some of the functions I added for testing the improvements could be removed once reviewed.