### PR TITLE
Print changed loglevel in readable text

### DIFF
--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -48,7 +48,7 @@ bool Logger::update() {
 
     if (Logger::getCurrentLevel() != level) {
         Logger::setLevel(level);
-        LOGF(INFO, "Log level changed to %d", level);
+        LOGF(INFO, "Log level changed to %s", Logger::get_level_identifier(level).c_str());
     }
 
     return true;

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -104,7 +104,7 @@ class Logger {
 
         void current_time(char* timestamp);
 
-        String get_level_identifier(Level lvl);
+        static String get_level_identifier(Level lvl);
 
         // Logging level
         Level level_{Level::INFO};


### PR DESCRIPTION
member function `get_level_identifier()` has to be `static`


```
[14:46:56]    INFO Configuration saved successfully
[14:46:56]    INFO Configuration forcibly saved to filesystem
[14:46:56]    INFO Log level changed to    INFO

[14:47:06]    INFO Configuration saved successfully
[14:47:06]    INFO Configuration forcibly saved to filesystem
[14:47:06]    INFO Log level changed to   DEBUG
```