### PR TITLE
Fixed Power Switch toggle mode boot issues

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1157,6 +1157,18 @@ void setup() {
         machineState = kPidNormal;
         setRuntimePidState(true);
     }
+
+    // For toggle switches, force PidOn to switch state mode
+    if (config.get<bool>("hardware.switches.power.enabled") && config.get<int>("hardware.switches.power.type") == Switch::TOGGLE) {
+        if (powerSwitch->isPressed()) {
+            setRuntimePidState(true);
+            machineState = kPidNormal;
+        }
+        else {
+            setRuntimePidState(false);
+            machineState = kPidDisabled;
+        }
+    }
 }
 
 void loop() {

--- a/src/powerHandler.h
+++ b/src/powerHandler.h
@@ -33,7 +33,7 @@ inline void checkPowerSwitch() {
             lastPowerSwitchPressed = powerSwitchPressed;
 
             if (powerSwitchPressed) {
-                if (machineState == kStandby) {
+                if (machineState == kStandby || machineState == kPidDisabled) {
                     machineState = kPidNormal;
                     resetStandbyTimer(kPidNormal);
                     setRuntimePidState(true);


### PR DESCRIPTION
added kPidDisabled to toggle switch so it can go to kPidNormal on boot, and set machineState to initial switch state on boot in case it was pidOn when switched off or switch in the on state when pidOn was last off.

I didn't add kInit to the powerHandler as it would flash the disabled screen on boot