### PR TITLE
Scale font fix, calibration langstrings

### DIFF
--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -737,3 +737,72 @@ inline bool displayMachineState() {
 
     return false;
 }
+
+inline void displayWrappedMessage(const String& message) {
+    u8g2->clearBuffer();
+
+    if (config.get<int>("display.template") == 4) {
+        u8g2->setFont(u8g2_font_profont10_tf);
+    }
+    else {
+        u8g2->setFont(u8g2_font_profont11_tf);
+    }
+
+    int lineHeight = u8g2->getMaxCharHeight() + 2;
+    int displayWidth = u8g2->getDisplayWidth();
+    int displayHeight = u8g2->getDisplayHeight();
+    int maxLines = displayHeight / lineHeight;
+
+    int x = 0;
+    int y = 0;
+    int wordCount = 0;
+
+    String word;
+    String line;
+
+    for (size_t i = 0; i <= message.length(); ++i) {
+        char c = message[i];
+
+        if (c == ' ' || c == '\n' || c == '\0') {
+            if (u8g2->getUTF8Width((line + word).c_str()) > displayWidth) {
+                u8g2->setCursor(x, y);
+
+                if (wordCount == 0) {
+                    u8g2->drawUTF8(x, y, word.c_str());
+                    y += lineHeight;
+                    line = "";
+                }
+                else {
+                    u8g2->drawUTF8(x, y, line.c_str());
+                    y += lineHeight;
+                    line = word + " ";
+                    wordCount = 1;
+                }
+            }
+            else {
+                line += word + " ";
+                wordCount += 1;
+            }
+
+            word = "";
+
+            if (c == '\n') {
+                u8g2->setCursor(x, y);
+                u8g2->drawUTF8(x, y, line.c_str());
+                y += lineHeight;
+                line = "";
+                wordCount = 0;
+            }
+        }
+        else {
+            word += c;
+        }
+    }
+
+    if (line.length() > 0 && y + lineHeight <= displayHeight) {
+        u8g2->setCursor(x, y);
+        u8g2->drawUTF8(x, y, line.c_str());
+    }
+
+    u8g2->sendBuffer();
+}

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -105,7 +105,9 @@ inline void printScreen() {
 
     if (config.get<bool>("hardware.sensors.pressure.enabled")) {
         u8g2->setCursor(32, 46);
-        u8g2->print(langstring_pressure);
+        u8g2->drawUTF8(32, 46, langstring_pressure);
+        int labelWidth = u8g2->getUTF8Width(langstring_pressure);
+        u8g2->setCursor(32 + labelWidth, 46);
         u8g2->print(inputPressure, 1);
     }
 

--- a/src/display/languages.h
+++ b/src/display/languages.h
@@ -19,8 +19,8 @@ static const char* langstring_uptime;
 static const char* langstring_offlinemode;
 static const char* langstring_wifirecon;
 static const char* langstring_connectwifi1;
-static const char* langstring_nowifi[32];
-static const char* langstring_error_tsensor[64];
+static const char* langstring_nowifi[2];
+static const char* langstring_error_tsensor[5];
 static const char* langstring_scale_Failure;
 static const char* langstring_backflush_press;
 static const char* langstring_backflush_start;
@@ -33,6 +33,9 @@ static const char* langstring_hot_water_ur;
 static const char* langstring_weight_ur;
 static const char* langstring_pressure_ur;
 static const char* langstring_error_tsensor_ur[5];
+static const char* langstring_calibrate_start;
+static const char* langstring_calibrate_in_progress;
+static const char* langstring_calibrate_complete;
 
 inline void initLangStrings(const Config& config) {
 
@@ -73,6 +76,10 @@ inline void initLangStrings(const Config& config) {
         langstring_backflush_press = "Press brew switch";
         langstring_backflush_start = "to start...";
         langstring_backflush_finish = "to finish...";
+
+        langstring_calibrate_start = "Calibration coming up\n\nEmpty scale ";
+        langstring_calibrate_in_progress = "Calibration in progress. Place known weight on scale in next 10 seconds ";
+        langstring_calibrate_complete = "Calibration done!\nNew result: ";
     }
     // Espanol
     else if (config.get<int>("display.language") == 2) {
@@ -111,6 +118,10 @@ inline void initLangStrings(const Config& config) {
         langstring_backflush_press = "Pulsa boton de cafe";
         langstring_backflush_start = "para empezar...";
         langstring_backflush_finish = "para terminar...";
+
+        langstring_calibrate_start = "Calibración iniciando\n\nVaciar la balanza ";
+        langstring_calibrate_in_progress = "Calibrando. Coloque un peso conocido en la balanza en los próximos 10 segundos ";
+        langstring_calibrate_complete = "Calibración completa!\nNuevo resultado: ";
     }
     // German (default)
     else {
@@ -148,5 +159,9 @@ inline void initLangStrings(const Config& config) {
         langstring_backflush_press = "Bruehsch. druecken";
         langstring_backflush_start = "um zu starten...";
         langstring_backflush_finish = "um zu beenden...";
+
+        langstring_calibrate_start = "Kalibrierung startet\n\nWaage leeren ";
+        langstring_calibrate_in_progress = "Kalibrierung läuft. Bitte in den nächsten 10 Sekunden ein bekanntes Gewicht auflegen ";
+        langstring_calibrate_complete = "Kalibrierung abgeschlossen!\nNeues Ergebnis: ";
     }
 }

--- a/src/scaleHandler.h
+++ b/src/scaleHandler.h
@@ -10,14 +10,11 @@ inline void scaleCalibrate(HX711_ADC loadCell, const int pin, const bool isSecon
     const int scaleSamples = config.get<int>("hardware.sensors.scale.samples");
 
     loadCell.setCalFactor(1.0);
+    String msg = langstring_calibrate_start + String((int)isSecondCell + 1) + "\n";
+    displayWrappedMessage(msg);
+    delay(2000);
 
-    u8g2->clearBuffer();
-    u8g2->drawStr(0, 22, "Calibration coming up");
-    u8g2->drawStr(0, 32, "Empty scale ");
-    u8g2->print(pin, 0);
-    u8g2->sendBuffer();
-
-    LOGF(INFO, "Taking scale %d to zero point", pin);
+    LOGF(INFO, "Taking scale %d, pin %d to zero point", (int)isSecondCell + 1, pin);
 
     loadCell.update();
     loadCell.tare();
@@ -26,13 +23,8 @@ inline void scaleCalibrate(HX711_ADC loadCell, const int pin, const bool isSecon
 
     const auto scaleKnownWeight = ParameterRegistry::getInstance().getParameterById("hardware.sensors.scale.known_weight")->getValueAs<float>();
 
-    u8g2->clearBuffer();
-    u8g2->drawStr(2, 2, "Calibration in progress.");
-    u8g2->drawStr(2, 12, "Place known weight");
-    u8g2->drawStr(2, 22, "on scale in next");
-    u8g2->drawStr(2, 32, "10 seconds");
-    u8g2->drawStr(2, 42, number2string(scaleKnownWeight));
-    u8g2->sendBuffer();
+    msg = langstring_calibrate_in_progress + String(number2string(scaleKnownWeight)) + "g\n";
+    displayWrappedMessage(msg);
     delay(10000);
 
     LOG(INFO, "Taking scale load point");
@@ -54,12 +46,8 @@ inline void scaleCalibrate(HX711_ADC loadCell, const int pin, const bool isSecon
         ParameterRegistry::getInstance().setParameterValue("hardware.sensors.scale.calibration", *calibration);
     }
 
-    u8g2->clearBuffer();
-    u8g2->drawStr(2, 2, "Calibration done!");
-    u8g2->drawStr(2, 12, "New calibration:");
-    u8g2->drawStr(2, 22, number2string(*calibration));
-    u8g2->sendBuffer();
-
+    msg = langstring_calibrate_complete + String(number2string(*calibration)) + "\n";
+    displayWrappedMessage(msg);
     delay(2000);
 }
 


### PR DESCRIPTION
Calibration is now showing the correct language
Font size is set so it is not too large
Wrapped message function takes a long string and splits it by word based on what will fit on the length of the screen
Changed labels to scale 1 and 2 instead of pin numbers
Fixed UTF8 formatting for pressure in Scale template