### PR TITLE
Add timer feature for BLE scales, improve memory management in AcaiaArduinoBLE library

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -109,6 +109,11 @@ This document describes all configuration parameters available in the `config.js
 - **Default**: `false`
 - **Description**: Show brew timer in fullscreen mode
 
+### `display.blescale_brew_timer`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Enable starting and stopping the brew timer on a connected BLE scale
+
 ### `display.fullscreen_manual_flush_timer`
 - **Type**: Boolean
 - **Default**: `false`
@@ -127,11 +132,6 @@ This document describes all configuration parameters available in the `config.js
     - `1`: Deutsch
     - `2`: Español
 - **Description**: OLED display language selection
-
-### `display.pid_off_logo`
-- **Type**: Boolean
-- **Default**: `true`
-- **Description**: Display fullscreen logo when PID is disabled
 
 ### `display.post_brew_timer_duration`
 - **Type**: Double (seconds)

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,11 +10,15 @@ board_build.filesystem = littlefs
 board_build.partitions = partitions_4M.csv
 
 build_flags =
+  -Os
+  -D CONFIG_MAX_FILENAME_LEN=64
+  -D CONFIG_MAX_URL_LEN=128
   -D CONFIG_ASYNC_TCP_MAX_ACK_TIME=5000
   -D CONFIG_ASYNC_TCP_PRIORITY=10
   -D CONFIG_ASYNC_TCP_QUEUE_SIZE=64
   -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
   -D CONFIG_ASYNC_TCP_STACK_SIZE=4096
+  -D DEFAULT_MAX_WS_CLIENTS=4
   -D CORE_DEBUG_LEVEL=0
   -D CONFIG_ARDUHAL_LOG_COLORS=0
   -D CONFIG_ASYNC_TCP_USE_WDT=0
@@ -41,7 +45,7 @@ lib_deps =
     ESP32Async/ESPAsyncWebServer @ 3.7.8
     git+https://github.com/tzapu/WiFiManager @ 2.0.17
     h2zero/NimBLE-Arduino@^2.3.2
-    git+https://github.com/rancilio-pid/AcaiaArduinoBLE#137f90a
+    git+https://github.com/rancilio-pid/AcaiaArduinoBLE#ccee257
 
 extra_scripts =
     pre:auto_firmware_version.py

--- a/src/Config.h
+++ b/src/Config.h
@@ -316,11 +316,11 @@ class Config {
             _configDefs.emplace("display.inverted", ConfigDef::forBool(false));
             _configDefs.emplace("display.language", ConfigDef::forInt(0, 0, 2));
             _configDefs.emplace("display.fullscreen_brew_timer", ConfigDef::forBool(false));
+            _configDefs.emplace("display.blescale_brew_timer", ConfigDef::forBool(false));
             _configDefs.emplace("display.fullscreen_manual_flush_timer", ConfigDef::forBool(false));
             _configDefs.emplace("display.fullscreen_hot_water_timer", ConfigDef::forBool(false));
             _configDefs.emplace("display.post_brew_timer_duration", ConfigDef::forDouble(POST_BREW_TIMER_DURATION, POST_BREW_TIMER_DURATION_MIN, POST_BREW_TIMER_DURATION_MAX));
             _configDefs.emplace("display.heating_logo", ConfigDef::forBool(true));
-            _configDefs.emplace("display.pid_off_logo", ConfigDef::forBool(true));
 
             // Hardware - OLED
             _configDefs.emplace("hardware.oled.enabled", ConfigDef::forBool(true));

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -36,7 +36,6 @@ extern bool featureFullscreenManualFlushTimer;
 extern bool featureFullscreenHotWaterTimer;
 extern double postBrewTimerDuration;
 extern bool featureHeatingLogo;
-extern bool featurePidOffLogo;
 extern bool steamON;
 extern bool backflushOn;
 extern double temperature;
@@ -551,10 +550,22 @@ void ParameterRegistry::initialize(Config& config) {
     );
 
     addBoolConfigParam(
+        "display.blescale_brew_timer",
+        "Enable BLE Scale Brew Timer",
+        sDisplaySection,
+        905,
+        nullptr,
+        "Enable starting and stopping the brew timer on a connected BLE scale."
+            "Note that there might be a certain delay between the command being sent and the timer on the scale actually starting."
+            "Consider disabling the internal brew timer if you want to use this feature.",
+        [&config] { return config.get<int>("hardware.sensors.scale.type") == 2; }
+    );
+
+    addBoolConfigParam(
         "display.fullscreen_manual_flush_timer",
         "Enable Fullscreen Manual Flush Timer",
         sDisplaySection,
-        905,
+        906,
         &featureFullscreenManualFlushTimer,
         "Enable fullscreen overlay during manual flush"
     );
@@ -563,7 +574,7 @@ void ParameterRegistry::initialize(Config& config) {
         "display.fullscreen_hot_water_timer",
         "Enable Fullscreen Hot Water Timer",
         sDisplaySection,
-        906,
+        907,
         &featureFullscreenHotWaterTimer,
         "Enable fullscreen overlay during hot water mode"
     );
@@ -573,7 +584,7 @@ void ParameterRegistry::initialize(Config& config) {
         "Post Brew Timer Duration (s)",
         kDouble,
         sDisplaySection,
-        907,
+        908,
         &postBrewTimerDuration,
         POST_BREW_TIMER_DURATION_MIN,
         POST_BREW_TIMER_DURATION_MAX,
@@ -584,18 +595,9 @@ void ParameterRegistry::initialize(Config& config) {
         "display.heating_logo",
         "Enable Heating Logo",
         sDisplaySection,
-        908,
+        909,
         &featureHeatingLogo,
         "full screen logo will be shown if temperature is 5°C below setpoint"
-    );
-
-    addBoolConfigParam(
-        "display.pid_off_logo",
-        "Enable 'PID Disabled' Logo",
-        sDisplaySection,
-        909,
-        &featurePidOffLogo,
-        "full screen logo will be shown if pid is disabled"
     );
 
     // MQTT section

--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -633,7 +633,7 @@ inline bool displayMachineState() {
     }
 
     // Offline logo
-    if (featurePidOffLogo == 1 && machineState == kPidDisabled) {
+    if (machineState == kPidDisabled) {
         u8g2->clearBuffer();
         u8g2->drawXBMP(38, 0, Off_Logo_width, Off_Logo_height, Off_Logo);
         u8g2->setCursor(0, 55);
@@ -643,7 +643,7 @@ inline bool displayMachineState() {
         return true;
     }
 
-    if (featurePidOffLogo == 1 && machineState == kStandby) {
+    if (machineState == kStandby) {
         u8g2->clearBuffer();
         u8g2->drawXBMP(38, 0, Off_Logo_width, Off_Logo_height, Off_Logo);
         u8g2->setCursor(36, 55);

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -44,7 +44,7 @@ inline void printScreen() {
         u8g2->setFont(u8g2_font_profont11_tf);
         displayMessage(langstring_error_tsensor_ur[0], langstring_error_tsensor_ur[1], String(temperature), langstring_error_tsensor_ur[2], langstring_error_tsensor_ur[3], langstring_error_tsensor_ur[4]);
     }
-    else if (config.get<bool>("display.pid_off_logo") && machineState == kStandby) {
+    else if (machineState == kStandby) {
         u8g2->drawXBMP(6, 50, Off_Logo_width, Off_Logo_height, Off_Logo);
         u8g2->setCursor(1, 110);
         u8g2->setFont(u8g2_font_profont10_tf);
@@ -72,7 +72,7 @@ inline void printScreen() {
         u8g2->drawLine(1, 126, pidOutput / 16.13 + 1, 126);
 
         // logos that only fill the lower half leaving temperatures, top and bottom boxes
-        if (config.get<bool>("display.pid_off_logo") && machineState == kPidDisabled) {
+        if (machineState == kPidDisabled) {
             u8g2->drawXBMP(6, 50, Off_Logo_width, Off_Logo_height, Off_Logo);
             u8g2->setCursor(1, 110);
             u8g2->setFont(u8g2_font_profont10_tf);

--- a/src/hardware/scales/BluetoothScale.cpp
+++ b/src/hardware/scales/BluetoothScale.cpp
@@ -118,6 +118,24 @@ void BluetoothScale::tare() {
     }
 }
 
+void BluetoothScale::startTimer() const {
+    if (connected) {
+        return bleScale->startTimer();
+    }
+}
+
+void BluetoothScale::stopTimer() const {
+    if (connected) {
+        return bleScale->stopTimer();
+    }
+}
+
+void BluetoothScale::resetTimer() const {
+    if (connected) {
+        return bleScale->resetTimer();
+    }
+}
+
 void BluetoothScale::setSamples(int samples) {
     // Most BLE scales handle sampling internally
 }

--- a/src/hardware/scales/BluetoothScale.h
+++ b/src/hardware/scales/BluetoothScale.h
@@ -23,6 +23,9 @@ class BluetoothScale : public Scale {
         void tare() override;
         void setSamples(int samples) override;
         [[nodiscard]] bool isConnected() const override;
+        void startTimer() const;
+        void stopTimer() const;
+        void resetTimer() const;
 
         void updateConnection();
         [[nodiscard]] bool isConnecting() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,7 +79,6 @@ bool featureFullscreenManualFlushTimer = false;
 bool featureFullscreenHotWaterTimer = false;
 double postBrewTimerDuration = POST_BREW_TIMER_DURATION;
 bool featureHeatingLogo = false;
-bool featurePidOffLogo = false;
 
 // WiFi
 WiFiManager wm;


### PR DESCRIPTION
- Improved the memory management of the BLE scale library:
   https://github.com/tatemazer/AcaiaArduinoBLE/commit/8bd00491ab1f6378cc5d081fb12f0cd2574f6ddc

- Improved the time it takes for the timer and tare commands to be written: 
   https://github.com/tatemazer/AcaiaArduinoBLE/commit/24f8d49d2a9712d51d0b131f9205dee3b06029d1

- Added config option for using the timer on a connected BLE scale
