### PR TITLE
Non-blocking dallas temperature sensor

### DIFF
--- a/src/hardware/tempsensors/TempSensorDallas.cpp
+++ b/src/hardware/tempsensors/TempSensorDallas.cpp
@@ -12,6 +12,7 @@ TempSensorDallas::TempSensorDallas(const int GPIOPin) {
     dallasSensor_->begin();
     dallasSensor_->getAddress(sensorDeviceAddress_, 0);
     dallasSensor_->setResolution(sensorDeviceAddress_, 10);
+    dallasSensor_->setWaitForConversion(false);
 
     // Request first temperature conversion directly:
     dallasSensor_->requestTemperaturesByAddress(sensorDeviceAddress_);


### PR DESCRIPTION
Set Dallas temperature sensor to asynchronous read, as each loop was taking around 200ms.

This causes an error with my fake sensor but significantly improves the loop timing of my genuine sensor.

There are over a dozen varieties of clone DS18B20 all with variations from the original specification, I do not have all types to test but this link shows most are closer to the original than my fake (Family C, 30ms read vs 750ms genuine). https://github.com/cpetrich/counterfeit_DS18B20.

If users have incompatible sensor this may disable their machine.

I did not change the resolution to 11 bit as there wasn't a lot of buffer between conversion finishing and the next read.