### PR TITLE
IP on boot, improved message handling

### DIFF
--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -468,8 +468,15 @@ inline void backflush() {
                 pumpRelay->off();
                 debugPumpState("Backflush", "off");
                 LOG(INFO, "Backflush: flushing into drip tray");
-                currBackflushState = kBackflushFlushing;
+
+                if (currBackflushCycles == backflushCycles) {
+                    currBackflushState = kBackflushEnding;
+                }
+                else {
+                    currBackflushState = kBackflushFlushing;
+                }
             }
+
             break;
 
         case kBackflushFlushing:
@@ -488,6 +495,14 @@ inline void backflush() {
                     currBackflushState = kBackflushFinished;
                 }
             }
+
+            break;
+
+        case kBackflushEnding:
+            if (millis() - startingTime > backflushFlushTime * 1000) {
+                currBackflushState = kBackflushFinished;
+            }
+
             break;
 
         case kBackflushFinished:

--- a/src/brewStates.h
+++ b/src/brewStates.h
@@ -30,5 +30,6 @@ enum BackflushState {
     kBackflushIdle = 10,
     kBackflushFilling = 20,
     kBackflushFlushing = 30,
-    kBackflushFinished = 40
+    kBackflushEnding = 40,
+    kBackflushFinished = 50
 };

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -41,8 +41,7 @@ inline void printScreen() {
         u8g2->drawXBMP(8, 50, Water_Tank_Empty_Logo_width, Water_Tank_Empty_Logo_height, Water_Tank_Empty_Logo);
     }
     else if (machineState == kSensorError) {
-        u8g2->setFont(u8g2_font_profont11_tf);
-        displayMessage(langstring_error_tsensor_ur[0], langstring_error_tsensor_ur[1], String(temperature), langstring_error_tsensor_ur[2], langstring_error_tsensor_ur[3], langstring_error_tsensor_ur[4]);
+        displayWrappedMessage(String(langstring_error_tsensor[0]) + String(temperature) + '\n' + String(langstring_error_tsensor[1]));
     }
     else if (machineState == kStandby) {
         u8g2->drawXBMP(6, 50, Off_Logo_width, Off_Logo_height, Off_Logo);
@@ -108,6 +107,10 @@ inline void printScreen() {
 
             if (machineState == kManualFlush) {
                 u8g2->print("FLUSH");
+            }
+            else if (machineState == kBackflush) {
+                u8g2->setFont(u8g2_font_profont15_tr);
+                u8g2->print("BACKFLUSH");
             }
             else if (shouldDisplayBrewTimer()) {
                 u8g2->print("BREW");

--- a/src/display/languages.h
+++ b/src/display/languages.h
@@ -19,8 +19,9 @@ static const char* langstring_uptime;
 static const char* langstring_offlinemode;
 static const char* langstring_wifirecon;
 static const char* langstring_connectwifi1;
+static const char* langstring_connectip;
 static const char* langstring_nowifi[2];
-static const char* langstring_error_tsensor[5];
+static const char* langstring_error_tsensor[2];
 static const char* langstring_scale_Failure;
 static const char* langstring_backflush_press;
 static const char* langstring_backflush_start;
@@ -32,7 +33,6 @@ static const char* langstring_manual_flush_ur;
 static const char* langstring_hot_water_ur;
 static const char* langstring_weight_ur;
 static const char* langstring_pressure_ur;
-static const char* langstring_error_tsensor_ur[5];
 static const char* langstring_calibrate_start;
 static const char* langstring_calibrate_in_progress;
 static const char* langstring_calibrate_complete;
@@ -60,18 +60,14 @@ inline void initLangStrings(const Config& config) {
 
         langstring_offlinemode = "Offline";
         langstring_wifirecon = "Wifi reconnect:";
-        langstring_connectwifi1 = "1: Connecting to WiFi:";
+        langstring_connectwifi1 = "Connecting to WiFi:";
+        langstring_connectip = "IP Address:";
         langstring_nowifi[0] = "No ";
         langstring_nowifi[1] = "WiFi";
 
         langstring_error_tsensor[0] = "Error, Temp: ";
-        langstring_error_tsensor[1] = "Check Temp. sensor!";
+        langstring_error_tsensor[1] = "Check temperature sensor!";
         langstring_scale_Failure = "Fault";
-        langstring_error_tsensor_ur[0] = "Error";
-        langstring_error_tsensor_ur[1] = "Temp: ";
-        langstring_error_tsensor_ur[2] = "check";
-        langstring_error_tsensor_ur[3] = "temp.";
-        langstring_error_tsensor_ur[4] = "sensor!";
 
         langstring_backflush_press = "Press brew switch";
         langstring_backflush_start = "to start...";
@@ -102,18 +98,14 @@ inline void initLangStrings(const Config& config) {
 
         langstring_offlinemode = "Offline";
         langstring_wifirecon = "Reconecta wifi:";
-        langstring_connectwifi1 = "1: Wifi conectado :";
+        langstring_connectwifi1 = "Wifi conectado:";
+        langstring_connectip = "Dirección IP:";
         langstring_nowifi[0] = "No ";
         langstring_nowifi[1] = "WIFI";
 
         langstring_error_tsensor[0] = "Error, Temp: ";
-        langstring_error_tsensor[1] = "Comprueba sensor T!";
+        langstring_error_tsensor[1] = "¡Revisa el sensor de temperatura!";
         langstring_scale_Failure = "falla";
-        langstring_error_tsensor_ur[0] = "Error";
-        langstring_error_tsensor_ur[1] = "Temp: ";
-        langstring_error_tsensor_ur[2] = "Comprueba";
-        langstring_error_tsensor_ur[3] = "sensor";
-        langstring_error_tsensor_ur[4] = "T!";
 
         langstring_backflush_press = "Pulsa boton de cafe";
         langstring_backflush_start = "para empezar...";
@@ -144,17 +136,13 @@ inline void initLangStrings(const Config& config) {
 
         langstring_offlinemode = "Offline";
         langstring_wifirecon = "Wifi reconnect:";
-        langstring_connectwifi1 = "1: Verbinde WLAN:";
+        langstring_connectwifi1 = "Verbinde WLAN:";
+        langstring_connectip = "IP-Adresse:";
         langstring_nowifi[0] = "Kein ";
         langstring_nowifi[1] = "WLAN";
         langstring_error_tsensor[0] = "Fehler, Temp: ";
         langstring_error_tsensor[1] = "Temp.-Sensor ueberpruefen!";
         langstring_scale_Failure = "Fehler";
-        langstring_error_tsensor_ur[0] = "Fehler";
-        langstring_error_tsensor_ur[1] = "Temp: ";
-        langstring_error_tsensor_ur[2] = "Temp.";
-        langstring_error_tsensor_ur[3] = "Sensor";
-        langstring_error_tsensor_ur[4] = "ueberpruefen!";
 
         langstring_backflush_press = "Bruehsch. druecken";
         langstring_backflush_start = "um zu starten...";

--- a/src/powerHandler.h
+++ b/src/powerHandler.h
@@ -93,7 +93,7 @@ inline void checkPowerSwitch() {
             u8g2->setPowerSave(0);
 
             // Display reboot message
-            displayMessage("REBOOTING", "Please wait...", "", "", "", "");
+            displayWrappedMessage("REBOOTING\nPlease wait...");
             delay(1000);
 
             performSafeShutdown();

--- a/src/scaleHandler.h
+++ b/src/scaleHandler.h
@@ -12,7 +12,7 @@
 #include "hardware/scales/HX711Scale.h"
 
 void displayScaleFailed();
-void displayWrappedMessage(const String& msg);
+void displayWrappedMessage(const String& message, int x = 0, int startY = 0, int spacing = 2, boolean clearSend = true, boolean wrapWord = false);
 
 inline bool scaleCalibrationOn = false;
 inline bool scaleTareOn = false;
@@ -223,17 +223,10 @@ inline void checkWeight() {
 
     if (scaleTareOn) {
         scaleTareOn = false;
-        u8g2->clearBuffer();
-        u8g2->drawStr(0, 2, "Taring scale,");
-        u8g2->drawStr(0, 12, "remove any load!");
-        u8g2->drawStr(0, 22, "....");
-        u8g2->sendBuffer();
+        displayWrappedMessage("Taring scale,\nremove any load!\n....", 0, 2);
         delay(2000);
-
         scale->tare();
-
-        u8g2->drawStr(0, 32, "done");
-        u8g2->sendBuffer();
+        displayWrappedMessage("Taring scale,\nremove any load!\n....\ndone", 0, 2);
         delay(2000);
     }
 }


### PR DESCRIPTION
Added IP address on boot, upright is split by octet.
Added a small delay if no scales enabled to give time to read the IP address.
Improved wrap message and UTF8 character recognition, previously it was possible to split a multibyte character during wrap.
Improved displayLogo messages by using wrap, so version is readable on all displays (unless it's really long).
Removed displayMessage as it is covered by the wrap message function.
Added kBackflushEnding to allow displaying the backflush finished message on the final flush.
Removed some langstrings that are no longer needed with wrap.
Added Backflush message to upright display.