### PR TITLE
Heap space optimisations

### DIFF
--- a/frontend/js/temp.js
+++ b/frontend/js/temp.js
@@ -198,10 +198,11 @@ const tzdateOptions = {
 };
 
 function makeTempChart(data) {
+    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const opts = {
         title: "Temperature History",
         ...getSize(chartDiv),
-        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), 'Europe/Berlin'),
+        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), localTz),
         series: [
             {
                 value: "{YYYY}-{MM}-{DD} {HH}:{mm}:{ss}"
@@ -236,7 +237,7 @@ function makeTempChart(data) {
         ],
         axes: [
             {
-                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), 'Europe/Berlin').toLocaleString("de-DE", tzdateOptions)),
+                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), localTz).toLocaleString("de-DE", tzdateOptions)),
             },
             {
                 scale: 'C',
@@ -249,10 +250,11 @@ function makeTempChart(data) {
 }
 
 function makeHeaterChart(data) {
+    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const opts = {
         title: "Heater Power History",
         ...getSize(heaterDiv),
-        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), 'Europe/Berlin'),
+        tzDate: ts => uPlot.tzDate(new Date(ts * 1e3), localTz),
         scales: {
             "%": {
                 auto: false,
@@ -279,7 +281,7 @@ function makeHeaterChart(data) {
         ],
         axes: [
             {
-                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), 'Europe/Berlin').toLocaleString("de-DE", tzdateOptions)),
+                values: (u, vals, space) => vals.map(v => uPlot.tzDate(new Date(v * 1e3), localTz).toLocaleString("de-DE", tzdateOptions)),
             },
             {
                 side: 3,

--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -26,9 +26,9 @@ inline double curTemp = 0.0;
 inline double tTemp = 0.0;
 inline double hPower = 0.0;
 
-#define HISTORY_LENGTH 600 // 30 mins of values (20 vals/min * 60 min) = 600 (7,2kb)
+#define HISTORY_LENGTH 600 // 20 mins of values (30 vals/min * 20 min) = 600 (3.6kb)
 
-static float tempHistory[3][HISTORY_LENGTH] = {};
+static int16_t tempHistory[3][HISTORY_LENGTH] = {};
 inline int historyCurrentIndex = 0;
 inline int historyValueCount = 0;
 
@@ -423,36 +423,58 @@ inline void serverSetup() {
     });
 
     server.on("/temperatures", HTTP_GET, [](AsyncWebServerRequest* request) {
-        const String json = getTempString();
-        request->send(200, "application/json", json);
+        AsyncResponseStream* response = request->beginResponseStream("application/json");
+        response->print('{');
+        response->print("\"currentTemp\":");
+        response->print(curTemp, 2);
+        response->print(",\"targetTemp\":");
+        response->print(tTemp, 2);
+        response->print(",\"heaterPower\":");
+        response->print(hPower, 2);
+        response->print('}');
+        request->send(response);
     });
 
-    // TODO: could send values also chunked and without json (but needs three
-    // endpoints then?)
-    // https://stackoverflow.com/questions/61559745/espasyncwebserver-serve-large-array-from-ram
     server.on("/timeseries", HTTP_GET, [](AsyncWebServerRequest* request) {
         AsyncResponseStream* response = request->beginResponseStream("application/json");
         response->addHeader("Connection", "close"); // Force connection close
 
-        JsonDocument doc;
+        response->print('{');
 
-        // for each value in mem history array, add json array element
-        auto currentTemps = doc["currentTemps"].to<JsonArray>();
-        auto targetTemps = doc["targetTemps"].to<JsonArray>();
-        auto heaterPowers = doc["heaterPowers"].to<JsonArray>();
+        response->print("\"currentTemps\":[");
+        bool first = true;
 
-        // go through history values backwards starting from currentIndex and
-        // wrap around beginning to include valueCount many values
         for (int i = mod(historyCurrentIndex - historyValueCount, HISTORY_LENGTH); i != mod(historyCurrentIndex, HISTORY_LENGTH); i = mod(i + 1, HISTORY_LENGTH)) {
-            currentTemps.add(round2(tempHistory[0][i]));
-            targetTemps.add(round2(tempHistory[1][i]));
-            heaterPowers.add(round2(tempHistory[2][i]));
+            if (!first) response->print(',');
+            first = false;
+            response->print(tempHistory[0][i] * 0.01f, 2);
         }
 
-        String out;
-        out.reserve(measureJson(doc) + 16);
-        serializeJson(doc, out);
-        request->send(200, "application/json", out);
+        response->print("],");
+
+        response->print("\"targetTemps\":[");
+        first = true;
+
+        for (int i = mod(historyCurrentIndex - historyValueCount, HISTORY_LENGTH); i != mod(historyCurrentIndex, HISTORY_LENGTH); i = mod(i + 1, HISTORY_LENGTH)) {
+            if (!first) response->print(',');
+            first = false;
+            response->print(tempHistory[1][i] * 0.01f, 2);
+        }
+
+        response->print("],");
+
+        response->print("\"heaterPowers\":[");
+        first = true;
+
+        for (int i = mod(historyCurrentIndex - historyValueCount, HISTORY_LENGTH); i != mod(historyCurrentIndex, HISTORY_LENGTH); i = mod(i + 1, HISTORY_LENGTH)) {
+            if (!first) response->print(',');
+            first = false;
+            response->print(tempHistory[2][i] * 0.01f, 2);
+        }
+
+        response->print("]}");
+
+        request->send(response);
     });
 
     server.on("/wifireset", HTTP_POST, [](AsyncWebServerRequest* request) {
@@ -620,11 +642,11 @@ inline void sendTempEvent(const double currentTemp, const double targetTemp, con
     // save all values in memory to show history
     if (skippedValues > 0 && skippedValues % SECONDS_TO_SKIP == 0) {
         // use array and int value for start index (round robin)
-        // one record (3 float values == 12 bytes) every three seconds, for half
-        // an hour -> 7.2kB of static memory
-        tempHistory[0][historyCurrentIndex] = static_cast<float>(currentTemp);
-        tempHistory[1][historyCurrentIndex] = static_cast<float>(targetTemp);
-        tempHistory[2][historyCurrentIndex] = static_cast<float>(heaterPower);
+        // one record (3 int values == 6 bytes) every two seconds, for twenty
+        // minutes -> 3.6kB of static memory
+        tempHistory[0][historyCurrentIndex] = static_cast<int16_t>(currentTemp * 100);
+        tempHistory[1][historyCurrentIndex] = static_cast<int16_t>(targetTemp * 100);
+        tempHistory[2][historyCurrentIndex] = static_cast<int16_t>(heaterPower * 100);
         historyCurrentIndex = (historyCurrentIndex + 1) % HISTORY_LENGTH;
         historyValueCount = min(HISTORY_LENGTH - 1, historyValueCount + 1);
         skippedValues = 0;
@@ -633,6 +655,8 @@ inline void sendTempEvent(const double currentTemp, const double targetTemp, con
         skippedValues++;
     }
 
-    events.send("ping", nullptr, millis());
-    events.send(getTempString().c_str(), "new_temps", millis());
+    if (events.count() > 0) {
+        events.send("ping", nullptr, millis());
+        events.send(getTempString().c_str(), "new_temps", millis());
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -875,6 +875,10 @@ void setup() {
         LOG(ERROR, "Failed to load config from filesystem!");
     }
 
+    if (config.get<bool>("hardware.leds.steam.enabled")) {
+        LOG(WARNING, "Steam LED interferes with USB console communication");
+    }
+
     hostname = config.get<String>("system.hostname");
 
     ParameterRegistry::getInstance().initialize(config);
@@ -1056,7 +1060,10 @@ void setup() {
             }
 
             if (config.get<bool>("hardware.sensors.scale.enabled")) {
-                mqttVars["targetBrewWeight"] = "brew.by_weight.target_weight";
+                if (config.get<bool>("brew.mode") == 1) {
+                    mqttVars["targetBrewWeight"] = "brew.by_weight.target_weight";
+                }
+
                 mqttVars["scaleCalibration"] = "hardware.sensors.scale.calibration";
 
                 if (config.get<int>("hardware.sensors.scale.type") == 0) {
@@ -1279,9 +1286,7 @@ void loopPid() {
         websiteUpdateRunning = true;
 
         // send temperatures to website endpoint
-        if (WiFi.status() == WL_CONNECTED && !offlineMode) {
-            sendTempEvent(temperature, brewSetpoint, pidOutput / 10); // pidOutput is promill, so /10 to get percent value
-        }
+        sendTempEvent(temperature, brewSetpoint, pidOutput / 10); // pidOutput is promill, so /10 to get percent value
 
         lastTempEvent = millis();
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -314,6 +314,7 @@ inline int writeSysParamsToMQTT(const bool continueOnError = true) {
                 }
 
                 LOGF(WARNING, "Parameter %s not found for MQTT topic %s, skipping", parameterId, mqttTopic);
+                ++mqttVarsIt;
                 continue;
             }
 
@@ -342,6 +343,7 @@ inline int writeSysParamsToMQTT(const bool continueOnError = true) {
                     }
 
                     LOGF(WARNING, "Skipping unknown parameter type for topic %s", mqttTopic);
+                    ++mqttVarsIt;
                     continue;
             }
 


### PR DESCRIPTION
Reduced the size of some arrays by converting unsigned long and float to unsigned int.
Webpage graphs now display in local time.
Data for webpage graphs are now always stored not just when connected.
Added a warning to the console when steam LED is active that publishes before steam LED stops the console communication.

This includes optimisations done to sending timeseries and temperature data by @fiendie 
