### PR TITLE
fix small build error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1669,8 +1669,8 @@ void looppid() {
     updateStandbyTimer();
     handleMachineState();
 
-    // Check if brew timer should be shown
-#if (FEATURE_BREWSWITCH == 1)
+    // Check if brew timer should be shown, only if Display is activated.
+#if (FEATURE_BREWSWITCH == 1 && OLED_DISPLAY != 0)
     shouldDisplayBrewTimer();
 #endif
 


### PR DESCRIPTION
fix build error from non inclusion of shouldDisplayBrewTimer() in main.cpp if OLED_DISPLAY == 0, but FEATURE_BREWSWITCH == 1

How it was:
// Display
#define OLED_DISPLAY    0
...
#define FEATURE_BREWSWITCH      1

resulted in build error because in main.cpp
// Check if brew timer should be shown, only if Display is activated.
#if (FEATURE_BREWSWITCH == 1)
    shouldDisplayBrewTimer(); # -> This is not included, because the display is configured to 0
...

I adjusted it to include the additional check:
... && OLED_DISPLAY != 0 ...

