### PR TITLE
Flush during backflush, fixed post brew timer

### DIFF
--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -694,6 +694,10 @@ inline bool displayOfflineMode() {
  */
 inline bool displayMachineState() {
 
+    if (shouldDisplayBrewTimer()) {
+        return false;
+    }
+
     if (displayOfflineMode()) {
         return true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -586,6 +586,12 @@ void handleMachineState() {
                 machineState = kPidNormal;
             }
 
+            if (currBackflushState == kBackflushIdle) {
+                if (manualFlush()) {
+                    machineState = kManualFlush;
+                }
+            }
+
             if (emergencyStop) {
                 machineState = kEmergencyStop;
             }


### PR DESCRIPTION
I added shoulddisplaybrewtimer check to the displaymachinestate function as the post brew data was not being displayed if not using a fullscreen brew timer.

I added the manualflush check if backflush is in idle state, now the head can be cleaned easier between backflushes