### PR TITLE
Fixed u8g2 disable causing crashes

### DIFF
--- a/auto_firmware_version.py
+++ b/auto_firmware_version.py
@@ -14,7 +14,7 @@ installed_pkgs = {dist.metadata['Name'] for dist in importlib.metadata.distribut
 missing_pkgs = required_pkgs - installed_pkgs
 
 if missing_pkgs:
-    env.Execute('$PYTHONEXE -m pip install dulwich --global-option="--pure"')
+    env.Execute('$PYTHONEXE -m pip install dulwich')
 
 from dulwich.repo import Repo
 from dulwich.porcelain import active_branch

--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -484,6 +484,9 @@ inline void serverSetup() {
 
         request->send(200, "text/plain", "WiFi settings are being reset. Rebooting...");
 
+        if (u8g2 != nullptr) {
+            u8g2->setPowerSave(1);
+        }
         // Defer slightly so the response gets sent before reboot
         delay(1000);
 
@@ -581,6 +584,11 @@ inline void serverSetup() {
         }
 
         request->send(200, "text/plain", "Restarting...");
+
+        if (u8g2 != nullptr) {
+            u8g2->setPowerSave(1);
+        }
+
         delay(100);
         ESP.restart();
     });
@@ -593,6 +601,10 @@ inline void serverSetup() {
         const bool removed = LittleFS.remove("/config.json");
 
         request->send(200, "text/plain", removed ? "Factory reset. Restarting..." : "Could not delete config.json. Restarting...");
+
+        if (u8g2 != nullptr) {
+            u8g2->setPowerSave(1);
+        }
 
         delay(100);
         ESP.restart();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -657,9 +657,7 @@ void handleMachineState() {
 
         case kStandby:
             {
-                bool oledEnabled = config.get<bool>("hardware.oled.enabled");
-
-                if (standbyModeRemainingTimeDisplayOffMillis == 0 && oledEnabled) {
+                if (standbyModeRemainingTimeDisplayOffMillis == 0 && u8g2 != nullptr) {
                     u8g2->setPowerSave(1);
                 }
 
@@ -667,7 +665,7 @@ void handleMachineState() {
                     machineState = kPidNormal;
                     resetStandbyTimer(machineState);
 
-                    if (oledEnabled) {
+                    if (u8g2 != nullptr) {
                         u8g2->setPowerSave(0);
                     }
                 }
@@ -676,7 +674,7 @@ void handleMachineState() {
                     machineState = kSteam;
                     resetStandbyTimer(machineState);
 
-                    if (oledEnabled) {
+                    if (u8g2 != nullptr) {
                         u8g2->setPowerSave(0);
                     }
                 }
@@ -686,7 +684,7 @@ void handleMachineState() {
                     machineState = kHotWater;
                     resetStandbyTimer(machineState);
 
-                    if (oledEnabled) {
+                    if (u8g2 != nullptr) {
                         u8g2->setPowerSave(0);
                     }
                 }
@@ -696,7 +694,7 @@ void handleMachineState() {
                     machineState = kBrew;
                     resetStandbyTimer(machineState);
 
-                    if (oledEnabled) {
+                    if (u8g2 != nullptr) {
                         u8g2->setPowerSave(0);
                     }
                 }
@@ -706,7 +704,7 @@ void handleMachineState() {
                     machineState = kManualFlush;
                     resetStandbyTimer(machineState);
 
-                    if (oledEnabled) {
+                    if (u8g2 != nullptr) {
                         u8g2->setPowerSave(0);
                     }
                 }
@@ -715,13 +713,13 @@ void handleMachineState() {
                     machineState = kBackflush;
                     resetStandbyTimer(machineState);
 
-                    if (oledEnabled) {
+                    if (u8g2 != nullptr) {
                         u8g2->setPowerSave(0);
                     }
                 }
 
                 if (tempSensor != nullptr && tempSensor->hasError()) {
-                    if (oledEnabled) {
+                    if (u8g2 != nullptr) {
                         u8g2->setPowerSave(0);
                     }
 
@@ -783,8 +781,6 @@ void wiFiSetup() {
     wm.setBreakAfterConfig(true);
     wm.setConnectRetries(3);
 
-    bool oledEnabled = config.get<bool>("hardware.oled.enabled");
-
     if (wm.getWiFiIsSaved()) {
         LOG(INFO, "Connecting to WiFi");
     }
@@ -799,7 +795,7 @@ void wiFiSetup() {
         wifiConnected = wm.startConfigPortal(hostname.c_str(), pass);
         wm.setConfigPortalTimeout(60); // sec timeout for captive portal
 
-        if (oledEnabled) {
+        if (u8g2 != nullptr) {
             displayLogo(String(langstring_portalAP) + "\n" + hostname);
         }
 
@@ -826,7 +822,7 @@ void wiFiSetup() {
         snprintf(fullMac, sizeof(fullMac), "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
         LOGF(INFO, "MAC-ADDRESS: %s", fullMac);
 
-        if (oledEnabled) {
+        if (u8g2 != nullptr) {
             displayLogo(String(langstring_connectwifi) + '\n' + wm.getWiFiSSID(true));
             delay(1500);
 
@@ -846,7 +842,7 @@ void wiFiSetup() {
     else {
         LOG(INFO, "WiFi connection timed out...");
 
-        if (oledEnabled) {
+        if (u8g2 != nullptr) {
             displayLogo(String(langstring_nowifi[0]) + '\n' + String(langstring_nowifi[1]));
         }
 
@@ -1151,7 +1147,7 @@ void setup() {
         previousMillisPressure = currentTime;
     }
 
-    if (config.get<bool>("hardware.oled.enabled")) {
+    if (u8g2 != nullptr) {
         if (!(config.get<bool>("hardware.sensors.scale.enabled") && config.get<int>("hardware.sensors.scale.type") < 2)) {
             delay(2000); // add delay if not hx711 to give time to display IP address
         }
@@ -1355,7 +1351,7 @@ void loopPid() {
 
     displayUpdateRunning = false;
 
-    if (config.get<bool>("hardware.oled.enabled")) {
+    if (u8g2 != nullptr) {
 
         // update display on loops that have not had other major tasks running, if blocked it will send in the next loop (average 0.5ms)
         if ((!websiteUpdateRunning && !mqttUpdateRunning && !hassioUpdateRunning && !temperatureUpdateRunning) || (millis() - lastDisplayUpdate > 500)) {

--- a/src/powerHandler.h
+++ b/src/powerHandler.h
@@ -37,7 +37,10 @@ inline void checkPowerSwitch() {
                     machineState = kPidNormal;
                     resetStandbyTimer(kPidNormal);
                     setRuntimePidState(true);
-                    u8g2->setPowerSave(0);
+
+                    if (u8g2 != nullptr) {
+                        u8g2->setPowerSave(0);
+                    }
                 }
             }
             else {
@@ -65,7 +68,10 @@ inline void checkPowerSwitch() {
                     machineState = kPidNormal;
                     resetStandbyTimer(kPidNormal);
                     setRuntimePidState(true);
-                    u8g2->setPowerSave(0);
+
+                    if (u8g2 != nullptr) {
+                        u8g2->setPowerSave(0);
+                    }
                 }
                 else {
                     performSafeShutdown();
@@ -90,7 +96,10 @@ inline void checkPowerSwitch() {
         if (powerSwitchPressed && systemInitialized && (currentMillis - systemInitializedTime > 5000) && trackingPressTime && (currentMillis - firstSwitchPressTime > 1000) && // Minimum 1 second actual press
             powerSwitch->longPressDetected()) {
             LOG(INFO, "Power switch long press detected - initiating system reboot");
-            u8g2->setPowerSave(0);
+
+            if (u8g2 != nullptr) {
+                u8g2->setPowerSave(0);
+            }
 
             // Display reboot message
             displayWrappedMessage("REBOOTING\nPlease wait...");
@@ -99,6 +108,15 @@ inline void checkPowerSwitch() {
             performSafeShutdown();
 
             LOG(INFO, "System reboot initiated");
+
+            if (u8g2 != nullptr) {
+                // if user has disabled display since last boot
+                if (!config.get<bool>("hardware.oled.enabled")) {
+                    delay(2000);
+                    u8g2->setPowerSave(1);
+                }
+            }
+
             delay(500);
 
             ESP.restart();


### PR DESCRIPTION
Changed some oled checks to if not nullptr instead of the config value as if the user changes from off to on it was immediately crashing, and it was freezing the display when going from on to off.

When display was disabled it would crash when waking from standby.

There is now a setPowerSave(1) before most restarts so the screen turns off, then it will turn back on if the parameter is enabled next boot.
