### PR TITLE
ISR fix and reinitialise on freeze

### DIFF
--- a/src/isr.h
+++ b/src/isr.h
@@ -11,13 +11,12 @@
 
 extern double pidOutput;
 
-unsigned int isrCounter = 0; // counter for ISR
+unsigned int isrCounter = 0;  // counter for ISR
+unsigned int isrWatchdog = 0; // test to verify ISR active
 unsigned long windowStartTime;
 unsigned int windowSize = 1000;
 
 void IRAM_ATTR onTimer() {
-    timerAlarmWrite(timer, 10000, true);
-
     if (pidOutput <= isrCounter) {
         heaterRelay->off();
     }
@@ -25,6 +24,7 @@ void IRAM_ATTR onTimer() {
         heaterRelay->on();
     }
 
+    isrWatchdog++;
     isrCounter += 10; // += 10 because one tick = 10ms
 
     // set PID output as relay commands
@@ -39,7 +39,7 @@ void IRAM_ATTR onTimer() {
 void initTimer1() {
     timer = timerBegin(0, 80, true);
     timerAttachInterrupt(timer, &onTimer, true);
-    timerAlarmWrite(timer, 10000, true);
+    timerAlarmWrite(timer, 10000, true); // set to automatically restart
 }
 
 void enableTimer1() {


### PR DESCRIPTION
timerAlarmWrite(timer, 10000, true); was being called each interrupt, even though it was already set to automatically restart. In rare cases this could corrupt causing the ISR to stop firing, which has been seen on multiple occasions where the heater is stuck on.

A counter has been added to enable checking if it is still active, and reinitialise it if it stops. It also turns the heater off during reinitialisation in case the timer stopped while the heater was on.

