### PR TITLE
Added check if preinfusion time is zero and skip to pause

### DIFF
--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -264,6 +264,10 @@ inline bool brew() {
                     LOG(INFO, "Brew running");
                     currBrewState = kBrewRunning;
                 }
+                else if (preinfusion == 0) {
+                    LOG(INFO, "Preinfusion was zero, Preinfusion pause running");
+                    currBrewState = kPreinfusionPause;
+                }
                 else {
                     LOG(INFO, "Preinfusion running");
                     currBrewState = kPreinfusion;


### PR DESCRIPTION
Added an extra check if preinfusion is set to zero, in the case when a user doesn't need pump assisted preinfusion but would like a pause.