### PR TITLE
MQTT machineState device discovery update

### DIFF
--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -538,7 +538,11 @@ inline DiscoveryObject GenerateSensorDevice(const char* name, const char* displa
     sensorConfigDoc["state_topic"] = String(topic_buffer);
     snprintf(topic_buffer, sizeof(topic_buffer), "%s-%s", unique_id, name);
     sensorConfigDoc["unique_id"] = String(topic_buffer);
-    sensorConfigDoc["unit_of_measurement"] = unit_of_measurement;
+
+    if (device_class != "enum") {
+        sensorConfigDoc["unit_of_measurement"] = unit_of_measurement;
+    }
+
     sensorConfigDoc["device_class"] = device_class;
     sensorConfigDoc["payload_available"] = "online";
     sensorConfigDoc["payload_not_available"] = "offline";


### PR DESCRIPTION
If unit_of_measurement is present in device auto discovery message for enum then history may not be saved in Home Assistant.
I added a check in the discovery message function to ignore unit_of_measurement for enum sensors like machineState