### PR TITLE
Fix several state machine issues

### DIFF
--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -839,10 +839,5 @@ inline bool displayMachineState() {
         return true;
     }
 
-    if (machineState == kEepromError) {
-        displayWrappedMessage("EEPROM Error,\nPlease set values");
-        return true;
-    }
-
     return false;
 }

--- a/src/hotWaterHandler.h
+++ b/src/hotWaterHandler.h
@@ -67,7 +67,7 @@ bool checkHotWaterStops() {
         debugHotWaterState(hotWaterStateDebug);
         return true;
     }
-    else if (machineState == kEmergencyStop || machineState == kSensorError || machineState == kEepromError) {
+    else if (machineState == kEmergencyStop || machineState == kSensorError) {
         hotWaterStateDebug = "off-error"; // turn off due to error
         debugHotWaterState(hotWaterStateDebug);
         return true;
@@ -200,7 +200,7 @@ inline void checkHotWaterSwitch() {
  * @brief Control the pump based on machine state
  * @return pumps state
  */
-inline bool hotWaterHandler(void) {
+inline bool hotWaterHandler() {
     if (!config.get<bool>("hardware.switches.hot_water.enabled") || hotWaterSwitch == nullptr) {
         return false; // hot water switch is not enabled
     }
@@ -240,7 +240,6 @@ inline bool hotWaterHandler(void) {
             break;
 
         case kHotWaterRunning:
-
             if (currHotWaterSwitchState == kHotWaterSwitchIdle && !checkBrewStates()) { // switch turned off and not in brew or flush
                 currHotWaterState = kHotWaterStopped;
                 hotWaterStateDebug = "off-sw";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -571,6 +571,7 @@ void handleMachineState() {
             if (standbyModeOn && standbyModeRemainingTimeMillis == 0) {
                 machineState = kStandby;
                 setRuntimePidState(false);
+                setSteamMode(false);
             }
 
             if (emergencyStop) {

--- a/src/steamHandler.h
+++ b/src/steamHandler.h
@@ -21,13 +21,21 @@ inline void checkSteamSwitch() {
     if (config.get<int>("hardware.switches.steam.type") == Switch::TOGGLE) {
         // Set steamON to 1 when steamswitch is HIGH
         if (steamSwitchReading == HIGH) {
-            steamON = true;
+            if (machineState != kStandby) {
+                steamON = true;
+            }
+            else if (currStateSteamSwitch == LOW) {
+                // only enable steam if we detected a transition from LOW to HIGH
+                steamON = true;
+            }
         }
 
         // if activated via web interface then steamFirstON == 1, prevent override
         if (steamSwitchReading == LOW && !steamFirstON) {
             steamON = false;
         }
+
+        currStateSteamSwitch = steamSwitchReading;
     }
     else if (config.get<int>("hardware.switches.steam.type") == Switch::MOMENTARY) {
         if (steamSwitchReading != currStateSteamSwitch) {


### PR DESCRIPTION
- Fix order of precedence in the state machine enum
- Make state transition checks consistend with the aforementioned order
- Add state transition from kSteam to kHotWater
- Remove unused kEepromError state