### PR TITLE
Auto boiler refill

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -274,6 +274,7 @@ class Config {
             _configDefs.emplace("steam.setpoint", ConfigDef::forDouble(STEAMSETPOINT, STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX));
             _configDefs.emplace("steam.auto_refill.enabled", ConfigDef::forBool(false));
             _configDefs.emplace("steam.auto_refill.duration", ConfigDef::forDouble(STEAM_AUTO_REFILL_DURATION, STEAM_AUTO_REFILL_DURATION_MIN, STEAM_AUTO_REFILL_DURATION_MAX));
+            _configDefs.emplace("steam.auto_refill.pressure", ConfigDef::forDouble(STEAM_AUTO_REFILL_PRESSURE, STEAM_AUTO_REFILL_PRESSURE_MIN, STEAM_AUTO_REFILL_PRESSURE_MAX));
 
             // Backflushing
             _configDefs.emplace("backflush.cycles", ConfigDef::forInt(BACKFLUSH_CYCLES, BACKFLUSH_CYCLES_MIN, BACKFLUSH_CYCLES_MAX));

--- a/src/Config.h
+++ b/src/Config.h
@@ -272,6 +272,8 @@ class Config {
 
             // Steam
             _configDefs.emplace("steam.setpoint", ConfigDef::forDouble(STEAMSETPOINT, STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX));
+            _configDefs.emplace("steam.auto_refill.enabled", ConfigDef::forBool(false));
+            _configDefs.emplace("steam.auto_refill.duration", ConfigDef::forDouble(STEAM_AUTO_REFILL_DURATION, STEAM_AUTO_REFILL_DURATION_MIN, STEAM_AUTO_REFILL_DURATION_MAX));
 
             // Backflushing
             _configDefs.emplace("backflush.cycles", ConfigDef::forInt(BACKFLUSH_CYCLES, BACKFLUSH_CYCLES_MIN, BACKFLUSH_CYCLES_MAX));

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -39,6 +39,8 @@ extern bool featureHeatingLogo;
 extern bool steamON;
 extern bool backflushOn;
 extern double temperature;
+extern bool steamAutoRefillEnabled;
+extern double steamAutoRefillDuration;
 extern bool scaleTareOn;
 extern bool scaleCalibrationOn;
 extern int logLevel;
@@ -216,6 +218,28 @@ void ParameterRegistry::initialize(Config& config) {
         STEAM_SETPOINT_MIN,
         STEAM_SETPOINT_MAX,
         "The temperature that the PID will use for steam mode"
+    );
+
+    addBoolConfigParam(
+        "steam.auto_refill.enabled",
+        "Enable Steam Auto-Refill",
+        sTempSection,
+        204,
+        &steamAutoRefillEnabled,
+        "Automatically refill boiler after steam usage by detecting temperature drops"
+    );
+
+    addNumericConfigParam<double>(
+        "steam.auto_refill.duration",
+        "Steam Refill Duration (s)",
+        kDouble,
+        sTempSection,
+        205,
+        &steamAutoRefillDuration,
+        STEAM_AUTO_REFILL_DURATION_MIN,
+        STEAM_AUTO_REFILL_DURATION_MAX,
+        "Duration to run hot water pump for boiler refill after steam usage",
+        [&config] { return config.get<bool>("steam.auto_refill.enabled"); }
     );
 
     // Brew Section

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -41,6 +41,7 @@ extern bool backflushOn;
 extern double temperature;
 extern bool steamAutoRefillEnabled;
 extern double steamAutoRefillDuration;
+extern double steamAutoRefillPressure;
 extern bool scaleTareOn;
 extern bool scaleCalibrationOn;
 extern int logLevel;
@@ -240,6 +241,19 @@ void ParameterRegistry::initialize(Config& config) {
         STEAM_AUTO_REFILL_DURATION_MAX,
         "Duration to run hot water pump for boiler refill after steam usage",
         [&config] { return config.get<bool>("steam.auto_refill.enabled"); }
+    );
+
+    addNumericConfigParam<double>(
+        "steam.auto_refill.pressure",
+        "Steam Refill Target Pressure (bar)",
+        kDouble,
+        sTempSection,
+        206,
+        &steamAutoRefillPressure,
+        STEAM_AUTO_REFILL_PRESSURE_MIN,
+        STEAM_AUTO_REFILL_PRESSURE_MAX,
+        "Stop refill when this pressure is reached (0 = disabled, requires pressure sensor)",
+        [&config] { return config.get<bool>("steam.auto_refill.enabled") && config.get<bool>("hardware.sensors.pressure.enabled"); }
     );
 
     // Brew Section

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -42,6 +42,7 @@
 #define POST_BREW_TIMER_DURATION   3.0               // time in seconds that brew timer will be shown after brew finished
 #define BLINKING_DELTA             0.3               // distance between measured temperature and setpoint to enable display blinking
 #define STEAM_AUTO_REFILL_DURATION 5.0               // default duration in seconds for steam auto-refill
+#define STEAM_AUTO_REFILL_PRESSURE 0.0               // default target pressure in bar for steam auto-refill (0 = disabled)
 #define MAXWIFIRECONNECTS          5                 // maximum number of reconnection attempts, use -1 to deactivate
 #define WIFICONNECTIONDELAY        10000             // delay between reconnects in ms
 #define MQTT_USERNAME              "rancilio"        // default MQTT username
@@ -101,6 +102,8 @@
 #define BLINKING_DELTA_MAX             10.0
 #define STEAM_AUTO_REFILL_DURATION_MIN 1.0
 #define STEAM_AUTO_REFILL_DURATION_MAX 60.0
+#define STEAM_AUTO_REFILL_PRESSURE_MIN 0.0
+#define STEAM_AUTO_REFILL_PRESSURE_MAX 3.0
 #define SCALE_SAMPLES_MIN              1
 #define SCALE_SAMPLES_MAX              20
 #define SCALE_CALIBRATION_MIN          (-999999.0)

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -12,101 +12,104 @@
 #define STR(x)        STR_HELPER(x)
 
 // default parameters
-#define HOSTNAME                 "silvia"          // default hostname
-#define OTAPASS                  "otapass"         // default password for over-the-air updates
-#define WM_PASS                  "CleverCoffee"    // default password for WiFiManager
-#define SETPOINT                 95.0              // brew temperature setpoint
-#define TEMPOFFSET               0.0               // brew temperature setpoint
-#define STEAMSETPOINT            120.0             // steam temperature setpoint
-#define SCALE_CALIBRATION_FACTOR 1.00              // Raw data is divided by this value to convert to readable data
-#define SCALE_KNOWN_WEIGHT       267.00            // Calibration weight for scale (weight of the tray)
-#define SCALE_SAMPLES            2                 // Number of samples used for calibration
-#define AGGKP                    62.0              // PID Kp (regular phase)
-#define AGGTN                    52.0              // PID Tn (regular phase)
-#define AGGTV                    11.5              // PID Tv (regular phase)
-#define AGGIMAX                  55.0              // PID Integrator Max (regular phase)
-#define STEAMKP                  150.0             // PID kp (steam phase)
-#define AGGBKP                   50.0              // PID Kp (brew detection phase)
-#define AGGBTN                   0.0               // PID Tn (brew detection phase)
-#define AGGBTV                   20.0              // PID Tv (brew detection phase)
-#define EMA_FACTOR               0.6               // Smoothing of input that is used for Tv (derivative component of PID). Smaller means less smoothing but also less delay, 0 means no filtering
-#define TARGET_BREW_TIME         25.0              // brew time in seconds (only used if pump is being controlled)
-#define BREW_PID_DELAY           10.0              // delay until enabling PID controller during brew (no heating during this time)
-#define PRE_INFUSION_TIME        2.0               // pre-infusion time in seconds
-#define PRE_INFUSION_PAUSE_TIME  5.0               // pre-infusion pause time in seconds
-#define TARGET_BREW_WEIGHT       36.0              // Target weight in grams
-#define STANDBY_MODE_TIME        35.0              // Time in minutes until the heater is turned off
-#define BACKFLUSH_CYCLES         5                 // number of cycles the backflush should run
-#define BACKFLUSH_FILL_TIME      5.0               // time in seconds the pump is running during backflush
-#define BACKFLUSH_FLUSH_TIME     10.0              // time in seconds the 3-way valve is open during backflush
-#define POST_BREW_TIMER_DURATION 3.0               // time in seconds that brew timer will be shown after brew finished
-#define BLINKING_DELTA           0.3               // distance between measured temperature and setpoint to enable display blinking
-#define MAXWIFIRECONNECTS        5                 // maximum number of reconnection attempts, use -1 to deactivate
-#define WIFICONNECTIONDELAY      10000             // delay between reconnects in ms
-#define MQTT_USERNAME            "rancilio"        // default MQTT username
-#define MQTT_PASSWORD            "silvia"          // default MQTT password
-#define MQTT_TOPIC               "custom/kitchen/" // default MQTT topic prefix
-#define MQTT_HASSIO_PREFIX       "homeassistant"   // default MQTT prefix for Home Assistant
-#define SCREEN_WIDTH             128               // OLED display width, in pixels
-#define SCREEN_HEIGHT            64                // OLED display height, in pixels
-#define AUTH_PASSWORD            "admin"           // default password for web authentication
-#define AUTH_USERNAME            "admin"           // default username for web authentication
+#define HOSTNAME                   "silvia"          // default hostname
+#define OTAPASS                    "otapass"         // default password for over-the-air updates
+#define WM_PASS                    "CleverCoffee"    // default password for WiFiManager
+#define SETPOINT                   95.0              // brew temperature setpoint
+#define TEMPOFFSET                 0.0               // brew temperature setpoint
+#define STEAMSETPOINT              120.0             // steam temperature setpoint
+#define SCALE_CALIBRATION_FACTOR   1.00              // Raw data is divided by this value to convert to readable data
+#define SCALE_KNOWN_WEIGHT         267.00            // Calibration weight for scale (weight of the tray)
+#define SCALE_SAMPLES              2                 // Number of samples used for calibration
+#define AGGKP                      62.0              // PID Kp (regular phase)
+#define AGGTN                      52.0              // PID Tn (regular phase)
+#define AGGTV                      11.5              // PID Tv (regular phase)
+#define AGGIMAX                    55.0              // PID Integrator Max (regular phase)
+#define STEAMKP                    150.0             // PID kp (steam phase)
+#define AGGBKP                     50.0              // PID Kp (brew detection phase)
+#define AGGBTN                     0.0               // PID Tn (brew detection phase)
+#define AGGBTV                     20.0              // PID Tv (brew detection phase)
+#define EMA_FACTOR                 0.6               // Smoothing of input that is used for Tv (derivative component of PID). Smaller means less smoothing but also less delay, 0 means no filtering
+#define TARGET_BREW_TIME           25.0              // brew time in seconds (only used if pump is being controlled)
+#define BREW_PID_DELAY             10.0              // delay until enabling PID controller during brew (no heating during this time)
+#define PRE_INFUSION_TIME          2.0               // pre-infusion time in seconds
+#define PRE_INFUSION_PAUSE_TIME    5.0               // pre-infusion pause time in seconds
+#define TARGET_BREW_WEIGHT         36.0              // Target weight in grams
+#define STANDBY_MODE_TIME          35.0              // Time in minutes until the heater is turned off
+#define BACKFLUSH_CYCLES           5                 // number of cycles the backflush should run
+#define BACKFLUSH_FILL_TIME        5.0               // time in seconds the pump is running during backflush
+#define BACKFLUSH_FLUSH_TIME       10.0              // time in seconds the 3-way valve is open during backflush
+#define POST_BREW_TIMER_DURATION   3.0               // time in seconds that brew timer will be shown after brew finished
+#define BLINKING_DELTA             0.3               // distance between measured temperature and setpoint to enable display blinking
+#define STEAM_AUTO_REFILL_DURATION 5.0               // default duration in seconds for steam auto-refill
+#define MAXWIFIRECONNECTS          5                 // maximum number of reconnection attempts, use -1 to deactivate
+#define WIFICONNECTIONDELAY        10000             // delay between reconnects in ms
+#define MQTT_USERNAME              "rancilio"        // default MQTT username
+#define MQTT_PASSWORD              "silvia"          // default MQTT password
+#define MQTT_TOPIC                 "custom/kitchen/" // default MQTT topic prefix
+#define MQTT_HASSIO_PREFIX         "homeassistant"   // default MQTT prefix for Home Assistant
+#define SCREEN_WIDTH               128               // OLED display width, in pixels
+#define SCREEN_HEIGHT              64                // OLED display height, in pixels
+#define AUTH_PASSWORD              "admin"           // default password for web authentication
+#define AUTH_USERNAME              "admin"           // default username for web authentication
 
-#define PID_KP_REGULAR_MIN            0.0
-#define PID_KP_REGULAR_MAX            999.0
-#define PID_TN_REGULAR_MIN            0.0
-#define PID_TN_REGULAR_MAX            999.0
-#define PID_TV_REGULAR_MIN            0.0
-#define PID_TV_REGULAR_MAX            999.0
-#define PID_I_MAX_REGULAR_MIN         0.0
-#define PID_I_MAX_REGULAR_MAX         999.0
-#define PID_KP_BD_MIN                 0.0
-#define PID_KP_BD_MAX                 999.0
-#define PID_TN_BD_MIN                 0.0
-#define PID_TN_BD_MAX                 999.0
-#define PID_TV_BD_MIN                 0.0
-#define PID_TV_BD_MAX                 999.0
-#define PID_EMA_FACTOR_MIN            0.0
-#define PID_EMA_FACTOR_MAX            1.0
-#define BREW_SETPOINT_MIN             20.0
-#define BREW_SETPOINT_MAX             110.0
-#define STEAM_SETPOINT_MIN            100.0
-#define STEAM_SETPOINT_MAX            140.0
-#define BREW_TEMP_OFFSET_MIN          0.0
-#define BREW_TEMP_OFFSET_MAX          20.0
-#define TARGET_BREW_TIME_MIN          1.0
-#define TARGET_BREW_TIME_MAX          120.0
-#define BREW_PID_DELAY_MIN            0.0
-#define BREW_PID_DELAY_MAX            60.0
-#define PRE_INFUSION_TIME_MIN         0.0
-#define PRE_INFUSION_TIME_MAX         60.0
-#define PRE_INFUSION_PAUSE_MIN        0.0
-#define PRE_INFUSION_PAUSE_MAX        60.0
-#define TARGET_BREW_WEIGHT_MIN        0.0
-#define TARGET_BREW_WEIGHT_MAX        500.0
-#define PID_KP_STEAM_MIN              0.0
-#define PID_KP_STEAM_MAX              999.0
-#define STANDBY_MODE_TIME_MIN         1.0
-#define STANDBY_MODE_TIME_MAX         120.0
-#define BACKFLUSH_CYCLES_MIN          2
-#define BACKFLUSH_CYCLES_MAX          20
-#define BACKFLUSH_FILL_TIME_MIN       3.0
-#define BACKFLUSH_FILL_TIME_MAX       10.0
-#define BACKFLUSH_FLUSH_TIME_MIN      5.0
-#define BACKFLUSH_FLUSH_TIME_MAX      20.0
-#define POST_BREW_TIMER_DURATION_MIN  0.0
-#define POST_BREW_TIMER_DURATION_MAX  60.0
-#define BLINKING_DELTA_MIN            0.2
-#define BLINKING_DELTA_MAX            10.0
-#define SCALE_SAMPLES_MIN             1
-#define SCALE_SAMPLES_MAX             20
-#define SCALE_CALIBRATION_MIN         (-999999.0)
-#define SCALE_CALIBRATION_MAX         999999.0
-#define SCALE_KNOWN_WEIGHT_MIN        1.0
-#define SCALE_KNOWN_WEIGHT_MAX        2000.0
-#define MQTT_BROKER_MAX_LENGTH        64
-#define USERNAME_MAX_LENGTH           32
-#define PASSWORD_MAX_LENGTH           64
-#define MQTT_TOPIC_MAX_LENGTH         48
-#define MQTT_HASSIO_PREFIX_MAX_LENGTH 24
-#define HOSTNAME_MAX_LENGTH           64
+#define PID_KP_REGULAR_MIN             0.0
+#define PID_KP_REGULAR_MAX             999.0
+#define PID_TN_REGULAR_MIN             0.0
+#define PID_TN_REGULAR_MAX             999.0
+#define PID_TV_REGULAR_MIN             0.0
+#define PID_TV_REGULAR_MAX             999.0
+#define PID_I_MAX_REGULAR_MIN          0.0
+#define PID_I_MAX_REGULAR_MAX          999.0
+#define PID_KP_BD_MIN                  0.0
+#define PID_KP_BD_MAX                  999.0
+#define PID_TN_BD_MIN                  0.0
+#define PID_TN_BD_MAX                  999.0
+#define PID_TV_BD_MIN                  0.0
+#define PID_TV_BD_MAX                  999.0
+#define PID_EMA_FACTOR_MIN             0.0
+#define PID_EMA_FACTOR_MAX             1.0
+#define BREW_SETPOINT_MIN              20.0
+#define BREW_SETPOINT_MAX              110.0
+#define STEAM_SETPOINT_MIN             100.0
+#define STEAM_SETPOINT_MAX             140.0
+#define BREW_TEMP_OFFSET_MIN           0.0
+#define BREW_TEMP_OFFSET_MAX           20.0
+#define TARGET_BREW_TIME_MIN           1.0
+#define TARGET_BREW_TIME_MAX           120.0
+#define BREW_PID_DELAY_MIN             0.0
+#define BREW_PID_DELAY_MAX             60.0
+#define PRE_INFUSION_TIME_MIN          0.0
+#define PRE_INFUSION_TIME_MAX          60.0
+#define PRE_INFUSION_PAUSE_MIN         0.0
+#define PRE_INFUSION_PAUSE_MAX         60.0
+#define TARGET_BREW_WEIGHT_MIN         0.0
+#define TARGET_BREW_WEIGHT_MAX         500.0
+#define PID_KP_STEAM_MIN               0.0
+#define PID_KP_STEAM_MAX               999.0
+#define STANDBY_MODE_TIME_MIN          1.0
+#define STANDBY_MODE_TIME_MAX          120.0
+#define BACKFLUSH_CYCLES_MIN           2
+#define BACKFLUSH_CYCLES_MAX           20
+#define BACKFLUSH_FILL_TIME_MIN        3.0
+#define BACKFLUSH_FILL_TIME_MAX        10.0
+#define BACKFLUSH_FLUSH_TIME_MIN       5.0
+#define BACKFLUSH_FLUSH_TIME_MAX       20.0
+#define POST_BREW_TIMER_DURATION_MIN   0.0
+#define POST_BREW_TIMER_DURATION_MAX   60.0
+#define BLINKING_DELTA_MIN             0.2
+#define BLINKING_DELTA_MAX             10.0
+#define STEAM_AUTO_REFILL_DURATION_MIN 1.0
+#define STEAM_AUTO_REFILL_DURATION_MAX 60.0
+#define SCALE_SAMPLES_MIN              1
+#define SCALE_SAMPLES_MAX              20
+#define SCALE_CALIBRATION_MIN          (-999999.0)
+#define SCALE_CALIBRATION_MAX          999999.0
+#define SCALE_KNOWN_WEIGHT_MIN         1.0
+#define SCALE_KNOWN_WEIGHT_MAX         2000.0
+#define MQTT_BROKER_MAX_LENGTH         64
+#define USERNAME_MAX_LENGTH            32
+#define PASSWORD_MAX_LENGTH            64
+#define MQTT_TOPIC_MAX_LENGTH          48
+#define MQTT_HASSIO_PREFIX_MAX_LENGTH  24
+#define HOSTNAME_MAX_LENGTH            64

--- a/src/hotWaterHandler.h
+++ b/src/hotWaterHandler.h
@@ -3,6 +3,10 @@
  *
  * @brief Handler for digital hot water switch
  */
+#pragma once
+
+// Forward declarations for steam auto-refill
+extern bool steamAutoRefillActive;
 
 uint8_t currStateHotWaterSwitch;
 
@@ -27,8 +31,9 @@ inline HotWaterState currHotWaterState = kHotWaterIdle;
 
 inline uint8_t hotWaterSwitchReading = LOW;
 inline uint8_t currReadingHotWaterSwitch = LOW;
-inline double currPumpOnTime = 0;          // current running total pump on time
-inline unsigned long pumpStartingTime = 0; // start time of pump
+inline double currPumpOnTime = 0;             // current running total pump on time
+inline unsigned long pumpStartingTime = 0;    // start time of pump
+inline bool hotWaterPumpIsAutoRefill = false; // True if pump is running due to steam auto-refill
 
 /**
  * @brief If set to publish debug messages then list what the current action is and what triggered it
@@ -227,20 +232,39 @@ inline bool hotWaterHandler() {
     switch (currHotWaterState) {
         case kHotWaterIdle: // waiting step for hot water switch turning on
 
+            // Check for auto-refill activation
+            if (steamAutoRefillActive && currHotWaterSwitchState == kHotWaterSwitchIdle) {
+                // Trigger pump start for auto-refill
+                currHotWaterSwitchState = kHotWaterSwitchShortPressed;
+                hotWaterPumpIsAutoRefill = true;
+                hotWaterStateDebug = "on-auto-refill";
+            }
+
             if (currHotWaterSwitchState == kHotWaterSwitchShortPressed) {
                 pumpRelay->on();
                 pumpStartingTime = millis();
                 currHotWaterState = kHotWaterRunning;
-                currPumpOnTime = 0;           // reset currPumpOnTime
+                currPumpOnTime = 0;               // reset currPumpOnTime
                 LOG(INFO, "Hot water pump started");
-                hotWaterStateDebug = "on-sw"; // turned on due to switch input
+                if (!hotWaterPumpIsAutoRefill) {
+                    hotWaterStateDebug = "on-sw"; // turned on due to switch input
+                }
                 debugHotWaterState(hotWaterStateDebug);
             }
 
             break;
 
         case kHotWaterRunning:
-            if (currHotWaterSwitchState == kHotWaterSwitchIdle && !checkBrewStates()) { // switch turned off and not in brew or flush
+            // Check if auto-refill should stop (timer expired in main.cpp sets steamAutoRefillActive = false)
+            if (steamAutoRefillActive == false && hotWaterPumpIsAutoRefill) {
+                // Auto-refill was stopped, turn off pump
+                currHotWaterState = kHotWaterStopped;
+                hotWaterPumpIsAutoRefill = false;
+                hotWaterStateDebug = "off-auto-refill";
+                debugHotWaterState(hotWaterStateDebug);
+            }
+            // Only check switch state if NOT in auto-refill mode (otherwise switch being idle would prematurely stop the pump)
+            else if (!hotWaterPumpIsAutoRefill && currHotWaterSwitchState == kHotWaterSwitchIdle && !checkBrewStates()) {
                 currHotWaterState = kHotWaterStopped;
                 hotWaterStateDebug = "off-sw";
                 debugHotWaterState(hotWaterStateDebug);
@@ -250,6 +274,7 @@ inline bool hotWaterHandler() {
 
         case kHotWaterStopped:
             pumpRelay->off();
+            hotWaterPumpIsAutoRefill = false; // Reset auto-refill flag when pump stops
 
             if (!checkHotWaterStops()) {
                 currHotWaterState = kHotWaterIdle;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,6 +214,16 @@ double temperature, pidOutput;
 bool steamON = false;
 bool steamFirstON = false;
 
+// Steam usage detection and auto-refill state tracking
+// Detects if steam was actually used (via unmonitored valve) by tracking temperature drop
+bool steamReachedOperatingTemp = false; // True if temperature reached operating range (near setpoint)
+double steamPeakTemp = 0.0;             // Highest temperature reached during steam session
+double steamMinTemp = 200.0;            // Lowest temperature during steam session (high initial value)
+bool steamAutoRefillActive = false;
+unsigned long steamRefillStartTime = 0;
+bool steamAutoRefillEnabled = false;
+double steamAutoRefillDuration = STEAM_AUTO_REFILL_DURATION;
+
 PID bPID(&temperature, &pidOutput, &setpoint, aggKp, aggKi, aggKd, 1, DIRECT);
 
 #include "brewHandler.h"
@@ -446,6 +456,14 @@ void handleMachineState() {
             if (steamON) {
                 machineState = kSteam;
 
+                // Initialize steam usage tracking when entering steam mode
+                // Only initialize once per session (check if already tracking)
+                if (steamPeakTemp == 0.0 && steamMinTemp == 200.0) {
+                    steamReachedOperatingTemp = false;
+                    steamPeakTemp = temperature; // Start tracking from current temperature
+                    steamMinTemp = temperature;  // Initialize min to current temp
+                }
+
                 if (standbyModeOn) {
                     resetStandbyTimer(machineState);
                 }
@@ -552,7 +570,42 @@ void handleMachineState() {
             break;
 
         case kSteam:
+            // Monitor temperature during steam mode to detect steam usage
+            // Steam usage is detected by temperature drop when user opens steam valve (not monitored)
+
+            // Check if temperature reached operating range (system was ready for steam)
+            if (temperature >= (steamSetpoint - 3.0)) {
+                steamReachedOperatingTemp = true;
+            }
+
+            // Track peak temperature (highest point reached, indicates system was ready)
+            if (temperature > steamPeakTemp) {
+                steamPeakTemp = temperature;
+            }
+
+            // Track minimum temperature (lowest point, shows drop from peak if steam was used)
+            if (temperature < steamMinTemp) {
+                steamMinTemp = temperature;
+            }
+
             if (!steamON) {
+                // Steam mode is being disabled - check if steam was actually used
+                if (steamAutoRefillEnabled && steamReachedOperatingTemp) {
+                    // Calculate temperature drop from peak (actual drop that occurred)
+                    const double tempDrop = steamPeakTemp - steamMinTemp;
+                    if (tempDrop > 5.0) {
+                        // Significant temperature drop detected - steam was used via valve
+                        steamAutoRefillActive = true;
+                        steamRefillStartTime = millis();
+                        LOGF(INFO, "Steam usage detected: temperature dropped %.1f°C from peak (%.1f°C to %.1f°C), triggering auto-refill", tempDrop, steamPeakTemp, steamMinTemp);
+                    }
+                }
+
+                // Reset tracking variables for next steam session
+                steamReachedOperatingTemp = false;
+                steamPeakTemp = 0.0;
+                steamMinTemp = 200.0;
+
                 machineState = kPidNormal;
             }
 
@@ -1380,6 +1433,17 @@ void loopPid() {
 
     updateStandbyTimer();
     handleMachineState();
+    // Handle steam auto-refill timer
+    if (steamAutoRefillActive) {
+        const unsigned long elapsedTime = millis() - steamRefillStartTime;
+        if (elapsedTime >= static_cast<unsigned long>(steamAutoRefillDuration * 1000)) {
+            // Refill duration completed, stop the refill
+            steamAutoRefillActive = false;
+            steamRefillStartTime = 0;
+            LOG(INFO, "Steam auto-refill completed");
+        }
+    }
+
     hotWaterHandler();
     valveSafetyShutdownCheck();
     testTimer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,6 +223,7 @@ bool steamAutoRefillActive = false;
 unsigned long steamRefillStartTime = 0;
 bool steamAutoRefillEnabled = false;
 double steamAutoRefillDuration = STEAM_AUTO_REFILL_DURATION;
+double steamAutoRefillPressure = STEAM_AUTO_REFILL_PRESSURE;
 
 PID bPID(&temperature, &pidOutput, &setpoint, aggKp, aggKi, aggKd, 1, DIRECT);
 
@@ -1433,14 +1434,29 @@ void loopPid() {
 
     updateStandbyTimer();
     handleMachineState();
-    // Handle steam auto-refill timer
+    // Handle steam auto-refill timer and pressure
     if (steamAutoRefillActive) {
         const unsigned long elapsedTime = millis() - steamRefillStartTime;
-        if (elapsedTime >= static_cast<unsigned long>(steamAutoRefillDuration * 1000)) {
-            // Refill duration completed, stop the refill
+        bool stopDueToTime = elapsedTime >= static_cast<unsigned long>(steamAutoRefillDuration * 1000);
+        bool stopDueToPressure = false;
+
+        // Check pressure if sensor is enabled and target pressure is set
+        if (config.get<bool>("hardware.sensors.pressure.enabled") && steamAutoRefillPressure > 0) {
+            if (inputPressureFilter >= steamAutoRefillPressure) {
+                stopDueToPressure = true;
+            }
+        }
+
+        if (stopDueToTime || stopDueToPressure) {
             steamAutoRefillActive = false;
             steamRefillStartTime = 0;
-            LOG(INFO, "Steam auto-refill completed");
+
+            if (stopDueToPressure) {
+                LOGF(INFO, "Steam auto-refill completed: target pressure %.2f bar reached", inputPressureFilter);
+            }
+            else {
+                LOG(INFO, "Steam auto-refill completed: duration reached");
+            }
         }
     }
 


### PR DESCRIPTION
Added auto boiler refill.

This feature detects if steam was used, by watching the temperature drop in steam mode.
When steam was used and the steam mode is disabled afterwards it automatically refills the boiler.
If a pressure sensor is installed, then the refill is stopped when a target pressure is reached, otherwise it stops after a given amount of seconds.
Both target pressure and amount of seconds can be changed in the settings.